### PR TITLE
EZP-24710: Paragraphs are stripped on the front-end if an XML block is published with the editor disabled

### DIFF
--- a/tests/lib/FieldType/Converter/_fixtures/expanding/input/008-table.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/expanding/input/008-table.xml
@@ -35,6 +35,13 @@
               </paragraph>
             </td>
           </tr>
+          <tr>
+            <td>
+              <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+                Simple text paragraph
+              </paragraph>
+            </td>
+          </tr>
         </table>
       </paragraph>
     </section>

--- a/tests/lib/FieldType/Converter/_fixtures/expanding/input/010-simpleParagraphs.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/expanding/input/010-simpleParagraphs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"
+         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+         xmlns:image="http://ez.no/namespaces/ezpublish3/image/">
+    <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">I'm not that temporary</paragraph>
+    <paragraph>I'm not temporary</paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/expanding/input/011-lists.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/expanding/input/011-lists.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"
+         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+         xmlns:image="http://ez.no/namespaces/ezpublish3/image/">
+     <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+         <ul>
+             <li>
+                 <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">Item with paragraph</paragraph>
+             </li>
+             <li>Item without paragraph</li>
+         </ul>
+     </paragraph>
+     <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+         <ol>
+             <li>
+                 <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">Item with paragraph</paragraph>
+             </li>
+             <li>Item without paragraph</li>
+         </ol>
+     </paragraph>
+     <ul>
+         <li>
+             <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">Item with paragraph</paragraph>
+         </li>
+         <li>Item without paragraph</li>
+     </ul>
+     <ol>
+         <li>
+             <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">Item with paragraph</paragraph>
+         </li>
+         <li>Item without paragraph</li>
+     </ol>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/expanding/output/008-table.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/expanding/output/008-table.xml
@@ -35,6 +35,13 @@
               </paragraph>
             </td>
           </tr>
+          <tr>
+            <td>
+              <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+                Simple text paragraph
+              </paragraph>
+            </td>
+          </tr>
         </table>
       </paragraph>
     </section>

--- a/tests/lib/FieldType/Converter/_fixtures/expanding/output/010-simpleParagraphs.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/expanding/output/010-simpleParagraphs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"
+         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+         xmlns:image="http://ez.no/namespaces/ezpublish3/image/">
+    <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">I'm not that temporary</paragraph>
+    <paragraph>I'm not temporary</paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/expanding/output/011-lists.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/expanding/output/011-lists.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"
+         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+         xmlns:image="http://ez.no/namespaces/ezpublish3/image/">
+     <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">
+         <ul>
+             <li>
+                 <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">Item with paragraph</paragraph>
+             </li>
+             <li>Item without paragraph</li>
+         </ul>
+     </paragraph>
+     <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">
+         <ol>
+             <li>
+                 <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">Item with paragraph</paragraph>
+             </li>
+             <li>Item without paragraph</li>
+         </ol>
+     </paragraph>
+     <ul>
+         <li>
+             <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">Item with paragraph</paragraph>
+         </li>
+         <li>Item without paragraph</li>
+     </ul>
+     <ol>
+         <li>
+             <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">Item with paragraph</paragraph>
+         </li>
+         <li>Item without paragraph</li>
+     </ol>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/input/009-itemizedList.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/input/009-itemizedList.xml
@@ -5,6 +5,7 @@
   <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
     <ul class="itemizedListClass">
       <li class="listItemClass"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">This is a list item.</paragraph></li>
+      <li class="listItemClass"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">This is a second list item.</paragraph></li>
     </ul>
   </paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/009-itemizedList.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/009-itemizedList.xml
@@ -2,5 +2,6 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <ul class="itemizedListClass">
     <li class="listItemClass">This is a list item.</li>
+    <li class="listItemClass">This is a second list item.</li>
   </ul>
 </section>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24710

# Description

When a XmlText field is  edited in the legacy admin interface with Online Editor disabled, the paragraphs are not rendered. This is happening because in this setup, the legacy eZSimplifiedInputParser generates the paragraph with the `xml:tmp` namespace definition and since the fix of [EZP-23513](https://jira.ez.no/browse/EZP-23513) (in https://github.com/ezsystems/ezpublish-kernel/pull/1087), those paragraphs are set as temporary and then ignored in the XSLT stylesheet.

This patch improves the temporary paragraph check to not use only the `xml:tmp` attribute as it seems the legacy input parsers are not strict enough on it.

## Tasks

* [x] Add a test on the expected behavior
* [x] Improve the handling of *temporary* paragraph to mark them as temporary when they are really supposed to be temporary
* [x] Fix the case of block custom tag (like `quote`, a test is failing  on this one)
* [x] Fix the case of paragraph as child of a list item

# Tests

unit tests + manual tests