### PR TITLE
EZP-25116: Impossible to add line break in header element

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/schemas/ezxml.xsd
+++ b/lib/FieldType/XmlText/Input/Resources/schemas/ezxml.xsd
@@ -39,6 +39,13 @@
   <xs:complexType name="header" mixed="true">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:group ref="commonInlineElements"/>
+      <xs:element name="line">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="commonInlineElements"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
     </xs:choice>
     <xs:attributeGroup ref="align"/>
     <xs:attribute name="anchor_name" type="xs:string"/>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/input/027-multilineheading.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/input/027-multilineheading.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+         xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+         xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+  <section>
+      <header>
+          <line>Multiple</line>
+          <line>Line</line>
+          <line>Heading</line>
+      </header>
+  </section>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/027-multilineheading.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/027-multilineheading.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
+    <a id="eztoc_1_1"/>
+    <h2>Multiple<br/>Line<br/>Heading</h2>
+</section>

--- a/tests/lib/FieldType/Input/EzXmlTest.php
+++ b/tests/lib/FieldType/Input/EzXmlTest.php
@@ -38,6 +38,21 @@ class EzXmlTest extends PHPUnit_Framework_TestCase
 <section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph><link href="" url="" url_id="1" object_remote_id="" object_id="1" node_id="1">test</link></paragraph></section>
 ',
             ),
+            array(
+                '<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><header><line>Multi</line><line>line</line></header></section>
+',
+            ),
+            array(
+                '<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><header><custom name="underline">Underline</custom></header></section>
+',
+            ),
+            array(
+                '<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><header><line><strong>Multi</strong></line><line><custom name="underline">line</custom></line></header></section>
+',
+            ),
         );
     }
 
@@ -75,6 +90,18 @@ class EzXmlTest extends PHPUnit_Framework_TestCase
 Element 'tr': Missing child element(s). Expected is one of ( th, td ).
 Element 'link', attribute 'node_id': 'abc' is not a valid value of the atomic type 'xs:integer'.
 Element 'link': This element is not expected. Expected is one of ( custom, strong, emphasize, embed, embed-inline ).",
+            ),
+            array(
+                '<?xml version="1.0" encoding="utf-8"?><section><header>With a literal<literal>literal</literal></header></section>',
+                "Argument 'xmlString' is invalid: Validation of XML content failed: Element 'literal': This element is not expected. Expected is one of ( custom, strong, emphasize, link, anchor, line ).",
+            ),
+            array(
+                '<?xml version="1.0" encoding="utf-8"?><section><header>With a embed <embed /></header></section>',
+                "Argument 'xmlString' is invalid: Validation of XML content failed: Element 'embed': This element is not expected. Expected is one of ( custom, strong, emphasize, link, anchor, line ).",
+            ),
+            array(
+                '<?xml version="1.0" encoding="utf-8"?><section><header>With a embed <embed-inline /></header></section>',
+                "Argument 'xmlString' is invalid: Validation of XML content failed: Element 'embed-inline': This element is not expected. Expected is one of ( custom, strong, emphasize, link, anchor, line ).",
             ),
         );
     }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25116

# Description

In the ezxml schema of XmlText, the `header` element does not accept `line` as a child while in legacy this is available since https://github.com/ezsystems/ezpublish-legacy/pull/930 ([EZP-22563](https://jira.ez.no/browse/EZP-22563)). As a result, it is impossible to represent a line break in a header.

This patch updates the ezxml schema (and the unit tests) to be consistent with the feature provided by the legacy Online Editor. This way the following ezxml document can be set on an XmlText fields:

```xml
<?xml version="1.0" encoding="utf-8"?>
<section>
  <header>
    <line>Header</line>
    <line><custom name="underline">underline</custom></line>
    <line>level</line>
    <line>1</line>
  </header>
</section>
```

and will be rendered as:

```html
<h2>Header<br><u>underline</u><br>level<br>1</h2>
```


## Tasks

* [x] Unit tests with the expected behavior (based on what legacy OE allows)
* [x] Fix to accept multi-line

# Tests

unit tests + manual tests