### PR TITLE
Updated dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
   ],
   "minimum-stability": "alpha",
   "require": {
-    "ezsystems/ezpublish-kernel": "~5.4.5 | ~6.0@dev"
+    "ezsystems/ezpublish-kernel": "^6.0@dev"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7",
     "matthiasnoback/symfony-dependency-injection-test": "0.*",
     "zendframework/zend-code": "~2.4.3",
-    "ezsystems/ezplatform-solr-search-engine": "~1.0.0@dev"
+    "ezsystems/ezplatform-solr-search-engine": "^1.0@dev"
   },
   "autoload": {
     "psr-4": {
@@ -30,7 +30,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0.x-dev"
+      "dev-master": "1.1.x-dev"
     }
   }
 }


### PR DESCRIPTION
Removes `ezpublish-kernel` 5.4, and sets branch-alias to 1.1.x-dev.