### PR TITLE
Fix EZP-25743: empty tagPreset error in fieldType validation

### DIFF
--- a/lib/FieldType/XmlText/Type.php
+++ b/lib/FieldType/XmlText/Type.php
@@ -276,7 +276,7 @@ class Type extends FieldType
                             self::TAG_PRESET_DEFAULT,
                             self::TAG_PRESET_SIMPLE_FORMATTING,
                         );
-                        if (!in_array($value, $definedTagPresets, true)) {
+                        if (!empty($value) && !in_array($value, $definedTagPresets, true)) {
                             $validationErrors[] = new ValidationError(
                                 "Setting '%setting%' is of unknown tag preset",
                                 null,

--- a/tests/lib/FieldType/XmlTextTest.php
+++ b/tests/lib/FieldType/XmlTextTest.php
@@ -93,6 +93,56 @@ class XmlTextTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers \eZ\Publish\Core\FieldType\XmlText\Type::validateFieldSettings
+     * @dataProvider providerForTestValidateFieldSettingsValid
+     */
+    public function testValidateFieldSettingsValid($settings)
+    {
+        $validationResult = $this->getFieldType()->validateFieldSettings($settings);
+
+        $this->assertInternalType(
+            'array',
+            $validationResult,
+            'The method validateFieldSettings() must return an array.'
+        );
+        $this->assertEquals(
+            array(),
+            $validationResult,
+            'validateFieldSettings() did consider the input settings invalid, which should be valid: '
+        );
+
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\FieldType\XmlText\Type::validateFieldSettings
+     * @dataProvider providerForTestValidateFieldSettingsInvalid
+     */
+    public function testValidateFieldSettingsInvalid($settings)
+    {
+        $validationResult = $this->getFieldType()->validateFieldSettings($settings);
+
+        $this->assertInternalType(
+            'array',
+            $validationResult,
+            'The method validateFieldSettings() must return an array.'
+        );
+
+        $this->assertNotEquals(
+            array(),
+            $validationResult,
+            'validateFieldSettings() did consider the input settings valid, which should be invalid.'
+        );
+
+        foreach ($validationResult as $actualResultElement) {
+            $this->assertInstanceOf(
+                'eZ\\Publish\\SPI\\FieldType\\ValidationError',
+                $actualResultElement,
+                'Validation result of incorrect type.'
+            );
+        }
+    }
+
+    /**
      * @covers \eZ\Publish\Core\FieldType\XmlText\Type::acceptValue
      * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
@@ -148,6 +198,48 @@ class XmlTextTest extends PHPUnit_Framework_TestCase
 
         self::assertInternalType('string', $fieldValue->data);
         self::assertSame($xmlDoc->saveXML(), $fieldValue->data);
+    }
+
+    public static function providerForTestValidateFieldSettingsValid()
+    {
+        return array(
+            array(
+                array(
+                    'numRows' => 10,
+                    'tagPreset' => ''
+                )
+            ),
+            array(
+                array(
+                    'numRows' => 10,
+                    'tagPreset' => 0,
+                )
+            ),
+        );
+    }
+
+    public static function providerForTestValidateFieldSettingsInvalid()
+    {
+        return array(
+            array(
+                array(
+                    'numRows' => '',
+                    'tagPreset' => ''
+                ),
+            ),
+            array(
+                array(
+                    'numRows' => 10,
+                    'tagPreset' => 'a'
+                )
+            ),
+            array(
+                array(
+                    'numRows' => 'a',
+                    'tagPreset' => 0
+                )
+            )
+        );
     }
 
     public static function providerForTestAcceptValueValidFormat()

--- a/tests/lib/FieldType/XmlTextTest.php
+++ b/tests/lib/FieldType/XmlTextTest.php
@@ -108,7 +108,7 @@ class XmlTextTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             array(),
             $validationResult,
-            'validateFieldSettings() did consider the input settings invalid, which should be valid: '
+            'validateFieldSettings() considered the input settings invalid, while they should be valid: '
         );
 
     }
@@ -130,7 +130,7 @@ class XmlTextTest extends PHPUnit_Framework_TestCase
         $this->assertNotEquals(
             array(),
             $validationResult,
-            'validateFieldSettings() did consider the input settings valid, which should be invalid.'
+            'validateFieldSettings() considered the input settings valid, while they should be invalid.'
         );
 
         foreach ($validationResult as $actualResultElement) {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25743
https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/12 against 1.1
