### PR TITLE
Fix EZP-26962: Error generated in log when viewing an XmlText field containing an embed with an external link

### DIFF
--- a/lib/FieldType/XmlText/Converter/EmbedLinking.php
+++ b/lib/FieldType/XmlText/Converter/EmbedLinking.php
@@ -90,10 +90,6 @@ class EmbedLinking implements Converter
         if ($link->hasAttribute('url')) {
             $embed->setAttribute(static::TEMP_PREFIX . 'url', $link->getAttribute('url'));
         }
-
-        if ($link->hasAttribute('url_id')) {
-            $embed->setAttribute(static::TEMP_PREFIX . 'url_id', $link->getAttribute('url_id'));
-        }
     }
 
     /**

--- a/lib/FieldType/XmlText/Converter/EmbedToHtml5.php
+++ b/lib/FieldType/XmlText/Converter/EmbedToHtml5.php
@@ -239,7 +239,7 @@ class EmbedToHtml5 implements Converter
         $id = $embed->getAttribute(EmbedLinking::TEMP_PREFIX . 'id');
         $class = $embed->getAttribute(EmbedLinking::TEMP_PREFIX . 'class');
         $resourceFragmentIdentifier = $embed->getAttribute(EmbedLinking::TEMP_PREFIX . 'anchor_name');
-        $resourceType = null;
+        $resourceType = static::LINK_RESOURCE_URL;
         $resourceId = null;
 
         if ($embed->hasAttribute(EmbedLinking::TEMP_PREFIX . 'object_id')) {
@@ -248,13 +248,6 @@ class EmbedToHtml5 implements Converter
         } elseif ($embed->hasAttribute(EmbedLinking::TEMP_PREFIX . 'node_id')) {
             $resourceType = static::LINK_RESOURCE_LOCATION;
             $resourceId = $embed->getAttribute(EmbedLinking::TEMP_PREFIX . 'node_id');
-        } elseif ($embed->hasAttribute(EmbedLinking::TEMP_PREFIX . 'url_id')) {
-            $resourceType = static::LINK_RESOURCE_URL;
-            $resourceId = $embed->getAttribute(EmbedLinking::TEMP_PREFIX . 'url_id');
-        } else {
-            $this->logger->error(
-                'Could not resolve XmlText embed link resource type and ID'
-            );
         }
 
         $parameters = array(

--- a/tests/lib/FieldType/Converter/EmbedToHtml5Test.php
+++ b/tests/lib/FieldType/Converter/EmbedToHtml5Test.php
@@ -133,7 +133,7 @@ url="http://ez.no"
                     'noLayout' => true,
                     'linkParameters' => array(
                         'href' => 'http://ez.no',
-                        'resourceType' => null,
+                        'resourceType' => 'URL',
                         'resourceId' => null,
                         'wrapped' => false,
                     ),
@@ -212,7 +212,7 @@ url="http://ez.no"
                     ),
                     'linkParameters' => array(
                         'href' => 'http://ez.no',
-                        'resourceType' => null,
+                        'resourceType' => 'URL',
                         'resourceId' => null,
                         'wrapped' => false,
                     ),
@@ -237,7 +237,6 @@ ezlegacytmp-embed-link-target="target"
 ezlegacytmp-embed-link-title="title"
 ezlegacytmp-embed-link-id="id"
 ezlegacytmp-embed-link-class="class"
-ezlegacytmp-embed-link-url_id="333"
 />
 </paragraph>
 </section>',
@@ -259,7 +258,7 @@ ezlegacytmp-embed-link-url_id="333"
                         'id' => 'id',
                         'class' => 'class',
                         'resourceType' => 'URL',
-                        'resourceId' => '333',
+                        'resourceId' => null,
                         'wrapped' => false,
                     ),
                 ),
@@ -327,7 +326,6 @@ node_id="114"
 size="medium"
 view="embed"
 url="http://ez.no"
-ezlegacytmp-embed-link-url_id="111"
 ezlegacytmp-embed-link-node_id="222"
 ezlegacytmp-embed-link-object_id="333"
 />
@@ -372,7 +370,6 @@ ezlegacytmp-embed-link-target="target"
 ezlegacytmp-embed-link-title="title"
 ezlegacytmp-embed-link-id="id"
 ezlegacytmp-embed-link-class="class"
-ezlegacytmp-embed-link-url_id="333"
 ezlegacytmp-embed-link-anchor_name="anchovy"
 />
 </link>
@@ -395,7 +392,7 @@ ezlegacytmp-embed-link-anchor_name="anchovy"
                         'id' => 'id',
                         'class' => 'class',
                         'resourceType' => 'URL',
-                        'resourceId' => '333',
+                        'resourceId' => null,
                         'resourceFragmentIdentifier' => 'anchovy',
                         'wrapped' => false,
                     ),
@@ -451,7 +448,6 @@ ezlegacytmp-embed-link-target="target"
 ezlegacytmp-embed-link-title="title"
 ezlegacytmp-embed-link-id="id"
 ezlegacytmp-embed-link-class="class"
-ezlegacytmp-embed-link-url_id="111"
 ezlegacytmp-embed-link-node_id="222"
 />
 </paragraph>
@@ -501,7 +497,6 @@ ezlegacytmp-embed-link-target="target"
 ezlegacytmp-embed-link-title="title"
 ezlegacytmp-embed-link-id="id"
 ezlegacytmp-embed-link-class="class"
-ezlegacytmp-embed-link-url_id="111"
 ezlegacytmp-embed-link-node_id="222"
 />
 and that was embedded
@@ -553,7 +548,6 @@ ezlegacytmp-embed-link-target="target"
 ezlegacytmp-embed-link-title="title"
 ezlegacytmp-embed-link-id="id"
 ezlegacytmp-embed-link-class="class"
-ezlegacytmp-embed-link-url_id="111"
 ezlegacytmp-embed-link-node_id="222"
 />
 </link>
@@ -996,12 +990,6 @@ ezlegacytmp-embed-link-node_id="222"
         $logger->expects($this->at(0))
             ->method('error')
             ->with(
-                'Could not resolve XmlText embed link resource type and ID'
-            );
-
-        $logger->expects($this->at(1))
-            ->method('error')
-            ->with(
                 'While generating embed for xmltext, could not locate Content object with ID 42'
             );
 
@@ -1068,12 +1056,6 @@ ezlegacytmp-embed-link-node_id="222"
             );
 
         $logger->expects($this->at(0))
-            ->method('error')
-            ->with(
-                'Could not resolve XmlText embed link resource type and ID'
-            );
-
-        $logger->expects($this->at(1))
             ->method('error')
             ->with(
                 'While generating embed for xmltext, could not locate Location with ID 42'

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/001-embedUrlLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/001-embedUrlLink.xml
@@ -2,7 +2,7 @@
 <section xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
          xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
-  <link url_id="72" url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
+  <link url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
     <embed view="embed" size="medium" custom:offset="0" custom:limit="5" object_id="110"/>
   </link>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/004-inlineEmbedUrlLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/004-inlineEmbedUrlLink.xml
@@ -4,7 +4,7 @@
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph>
     Look!
-    <link url_id="72" url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
+    <link url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
       <embed-inline view="embed" size="medium" custom:offset="0" custom:limit="5" object_id="110"/>
     </link>
     It's an embed!

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/006-inlineEmbedContentLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/006-inlineEmbedContentLink.xml
@@ -4,7 +4,7 @@
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph>
     An embed again...
-    <link object_id="72" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
+    <link anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
       <embed-inline view="embed" size="medium" custom:offset="0" custom:limit="5" object_id="110"/>
     </link>
   </paragraph>

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/007-inlineEmbedUrlLinkMixed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/007-inlineEmbedUrlLinkMixed.xml
@@ -4,7 +4,7 @@
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph>
     Yawn...
-    <link url_id="72" url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
+    <link url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
       <embed-inline view="embed" size="medium" custom:offset="0" custom:limit="5" object_id="110"/>
       another embed...
     </link>

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/001-embedUrlLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/001-embedUrlLink.xml
@@ -8,7 +8,6 @@
       custom:offset="0"
       custom:limit="5"
       object_id="110"
-      ezlegacytmp-embed-link-url_id="72"
       ezlegacytmp-embed-link-url="http://www.hr"
       ezlegacytmp-embed-link-anchor_name="fragment"
       ezlegacytmp-embed-link-target="_blank"

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/004-inlineEmbedUrlLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/004-inlineEmbedUrlLink.xml
@@ -11,7 +11,6 @@
         ezlegacytmp-embed-link-target="_blank"
         ezlegacytmp-embed-link-title="title"
         ezlegacytmp-embed-link-url="http://www.hr"
-        ezlegacytmp-embed-link-url_id="72"
         object_id="110"
         size="medium"
         view="embed"

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/006-inlineEmbedContentLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/006-inlineEmbedContentLink.xml
@@ -8,7 +8,6 @@
         ezlegacytmp-embed-link-anchor_name="fragment"
         ezlegacytmp-embed-link-class="class"
         ezlegacytmp-embed-link-id="id"
-        ezlegacytmp-embed-link-object_id="72"
         ezlegacytmp-embed-link-target="_blank"
         ezlegacytmp-embed-link-title="title"
         object_id="110"

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/007-inlineEmbedUrlLinkMixed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/007-inlineEmbedUrlLinkMixed.xml
@@ -4,14 +4,13 @@
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph>
     Yawn...
-    <link anchor_name="fragment" class="class" target="_blank" url="http://www.hr" url_id="72" xhtml:id="id" xhtml:title="title"><embed-inline
+    <link anchor_name="fragment" class="class" target="_blank" url="http://www.hr" xhtml:id="id" xhtml:title="title"><embed-inline
         ezlegacytmp-embed-link-anchor_name="fragment"
         ezlegacytmp-embed-link-class="class"
         ezlegacytmp-embed-link-id="id"
         ezlegacytmp-embed-link-target="_blank"
         ezlegacytmp-embed-link-title="title"
         ezlegacytmp-embed-link-url="http://www.hr"
-        ezlegacytmp-embed-link-url_id="72"
         object_id="110"
         size="medium"
         view="embed" custom:limit="5"


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26962

Same as https://github.com/ezsystems/ezpublish-kernel-ee/pull/152, just waiting for Travis to pass