### PR TITLE
Improvements in tests setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ matrix:
           env: TEST_CONFIG="phpunit.xml"
         - php: 7.0
           env: TEST_CONFIG="phpunit.xml"
+        - php: 7.1
+          env: TEST_CONFIG="phpunit.xml"
         - php: 5.5
           env: TEST_CONFIG="phpunit-integration-legacy.xml"
         - php: 5.6
           env: TEST_CONFIG="phpunit-integration-legacy.xml"
-        - php: 7.0
+        - php: 7.1
           env: TEST_CONFIG="phpunit-integration-legacy.xml"
         - php: 5.6
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,20 @@ matrix:
         - php: 5.4
           env: TEST_CONFIG="phpunit.xml"
         - php: 5.5
+          env: TEST_CONFIG="phpunit.xml"
+        - php: 5.6
+          env: TEST_CONFIG="phpunit.xml"
+        - php: 7.0
+          env: TEST_CONFIG="phpunit.xml"
+        - php: 5.5
           env: TEST_CONFIG="phpunit-integration-legacy.xml"
         - php: 5.6
+          env: TEST_CONFIG="phpunit-integration-legacy.xml"
+        - php: 7.0
+          env: TEST_CONFIG="phpunit-integration-legacy.xml"
+        - php: 5.6
+          env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
+        - php: 7.0
           env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" SOLR_VERSION="4.10.4" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
 
 # test only master (+ Pull requests)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "phpunit/phpunit": "~4.7",
     "matthiasnoback/symfony-dependency-injection-test": "0.*",
     "zendframework/zend-code": "~2.4.3",
-    "ezsystems/ezplatform-solr-search-engine": "^1.0@dev"
+    "ezsystems/ezplatform-solr-search-engine": "^1.0@dev,<1.3"
   },
   "autoload": {
     "psr-4": {

--- a/tests/lib/FieldType/Converter/EmbedToHtml5Test.php
+++ b/tests/lib/FieldType/Converter/EmbedToHtml5Test.php
@@ -632,13 +632,16 @@ ezlegacytmp-embed-link-node_id="222"
         $repository = $this
             ->getMockBuilder($repositoryClass)
             ->disableOriginalConstructor()
-            ->setMethods(
-                array_diff(
-                    get_class_methods($repositoryClass),
-                    array('sudo')
-                )
-            )
             ->getMock();
+
+        $repository->expects($this->any())
+            ->method('sudo')
+            ->with($this->anything())
+            ->will($this->returnCallback(
+                function ($callback) use ($repository) {
+                    return $callback($repository);
+                }
+            ));
 
         $repository->expects($this->any())
             ->method('getContentService')
@@ -685,7 +688,7 @@ ezlegacytmp-embed-link-node_id="222"
 
         $repository = $this->getMockRepository($contentService, null);
         foreach ($permissionsMap as $index => $permissions) {
-            $repository->expects($this->at($index + 1))
+            $repository->expects($this->at($index + 2))
                 ->method('canUser')
                 ->with(
                     $permissions[0],
@@ -751,7 +754,7 @@ ezlegacytmp-embed-link-node_id="222"
 
         $repository = $this->getMockRepository(null, $locationService);
         foreach ($permissionsMap as $index => $permissions) {
-            $repository->expects($this->at($index + 1))
+            $repository->expects($this->at($index + 2))
                 ->method('canUser')
                 ->with(
                     $permissions[0],
@@ -873,7 +876,7 @@ ezlegacytmp-embed-link-node_id="222"
 
         $repository = $this->getMockRepository($contentService, null);
         foreach ($permissionsMap as $index => $permissions) {
-            $repository->expects($this->at($index + 1))
+            $repository->expects($this->at($index + 2))
                 ->method('canUser')
                 ->with(
                     $permissions[0],
@@ -920,13 +923,13 @@ ezlegacytmp-embed-link-node_id="222"
             ->will($this->returnValue($location));
 
         $repository = $this->getMockRepository(null, $locationService);
-        $repository->expects($this->at(1))
+        $repository->expects($this->at(2))
             ->method('canUser')
             ->with('content', 'read', $contentInfo, $location)
             ->will(
                 $this->returnValue(false)
             );
-        $repository->expects($this->at(2))
+        $repository->expects($this->at(3))
             ->method('canUser')
             ->with('content', 'view_embed', $contentInfo, $location)
             ->will(


### PR DESCRIPTION
Sudo method needs to be mocked to run the tests on newer versions of eZ kernel, due to introduction of permissions resolver.

Also adds some more variations of tests to matrix on Travis.

Finally, we limit Solr bundle to 1.2 because master installs config for Solr 6