### PR TITLE
EZP-27396 Fixing inline object embeding

### DIFF
--- a/lib/FieldType/XmlText/Converter/EmbedToHtml5.php
+++ b/lib/FieldType/XmlText/Converter/EmbedToHtml5.php
@@ -182,6 +182,9 @@ class EmbedToHtml5 implements Converter
                 // Remove empty embed
                 $embed->parentNode->removeChild($embed);
             } else {
+                while ($embed->hasChildNodes()) {
+                    $embed->removeChild($embed->firstChild);
+                }
                 $embed->appendChild($xmlDoc->createCDATASection($embedContent));
             }
         }


### PR DESCRIPTION
This is a fix for https://jira.ez.no/browse/EZP-27396

## Description
Embeding inline objects in case it's only element in paragraph produces following xml which is then saved into DB:
```
<paragraph><embed-inline view="embed-inline" size="medium" object_id="126">ezembed</embed-inline></paragraph>
```

The **ezembed** part was not removed by `EmbedToHtml5` which resulted in invalid object embeding on further processing.

Fixing this is just clearing text content of XmlNode in case of `<embed>` and `<embed-inline>` elements

