### PR TITLE
Use new storage gateway API for 6.11 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,12 @@ language: php
 
 matrix:
     include:
-        - php: 5.4
-          env: TEST_CONFIG="phpunit.xml"
-        - php: 5.5
-          env: TEST_CONFIG="phpunit.xml"
         - php: 5.6
           env: TEST_CONFIG="phpunit.xml"
         - php: 7.0
           env: TEST_CONFIG="phpunit.xml"
         - php: 7.1
           env: TEST_CONFIG="phpunit.xml"
-        - php: 5.5
-          env: TEST_CONFIG="phpunit-integration-legacy.xml"
         - php: 5.6
           env: TEST_CONFIG="phpunit-integration-legacy.xml"
         - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.1.x-dev"
+      "dev-master": "1.3.x-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "minimum-stability": "alpha",
   "require": {
-    "ezsystems/ezpublish-kernel": "^6.0@dev"
+    "ezsystems/ezpublish-kernel": "^6.11@dev"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7",

--- a/lib/FieldType/XmlText/XmlTextStorage.php
+++ b/lib/FieldType/XmlText/XmlTextStorage.php
@@ -10,7 +10,7 @@
  */
 namespace eZ\Publish\Core\FieldType\XmlText;
 
-use eZ\Publish\Core\FieldType\GatewayBasedStorage;
+use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 
@@ -21,7 +21,7 @@ class XmlTextStorage extends GatewayBasedStorage
      */
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        $update = $this->getGateway($context)->storeFieldData($versionInfo, $field);
+        $update = $this->gateway->storeFieldData($versionInfo, $field);
 
         if ($update) {
             return true;
@@ -37,16 +37,13 @@ class XmlTextStorage extends GatewayBasedStorage
      */
     public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        $this->getGateway($context)->getFieldData($field);
+        $this->gateway->getFieldData($field);
     }
 
     public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds, array $context)
     {
-        /** @var \eZ\Publish\Core\FieldType\XmlText\XmlTextStorage\Gateway $gateway */
-        $gateway = $this->getGateway($context);
-
         foreach ($fieldIds as $fieldId) {
-            $gateway->unlinkUrl($fieldId, $versionInfo->versionNo);
+            $this->gateway->unlinkUrl($fieldId, $versionInfo->versionNo);
         }
     }
 

--- a/lib/FieldType/XmlText/XmlTextStorage/Gateway.php
+++ b/lib/FieldType/XmlText/XmlTextStorage/Gateway.php
@@ -10,7 +10,7 @@
  */
 namespace eZ\Publish\Core\FieldType\XmlText\XmlTextStorage;
 
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;

--- a/lib/FieldType/XmlText/XmlTextStorage/Gateway/LegacyStorage.php
+++ b/lib/FieldType/XmlText/XmlTextStorage/Gateway/LegacyStorage.php
@@ -15,50 +15,22 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
 use DOMDocument;
 use PDO;
-use RuntimeException;
 
 class LegacyStorage extends Gateway
 {
+    /**
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
     protected $dbHandler;
 
-    /**
-     * Set database handler for this gateway.
-     *
-     * @param mixed $dbHandler
-     *
-     * @throws RuntimeException if $dbHandler is not an instance of
-     *         {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler}
-     */
-    public function setConnection($dbHandler)
+    public function __construct(DatabaseHandler $dbHandler, UrlGateway $urlGateway)
     {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!$dbHandler instanceof DatabaseHandler) {
-            throw new RuntimeException('Invalid dbHandler passed');
-        }
+        parent::__construct($urlGateway);
 
-        $this->urlGateway->setConnection($dbHandler);
         $this->dbHandler = $dbHandler;
-    }
-
-    /**
-     * Returns the active connection.
-     *
-     * @throws RuntimeException if no connection has been set, yet.
-     *
-     * @return DatabaseHandler
-     */
-    protected function getConnection()
-    {
-        if ($this->dbHandler === null) {
-            throw new RuntimeException('Missing database connection.');
-        }
-
-        return $this->dbHandler;
     }
 
     /**
@@ -237,7 +209,7 @@ class LegacyStorage extends Gateway
 
         if (!empty($linksRemoteIds)) {
             /** @var $q \eZ\Publish\Core\Persistence\Database\SelectQuery */
-            $q = $this->getConnection()->createSelectQuery();
+            $q = $this->dbHandler->createSelectQuery();
             $q
                 ->select('id', 'remote_id')
                 ->from('ezcontentobject')

--- a/lib/settings/fieldtype_external_storages.yml
+++ b/lib/settings/fieldtype_external_storages.yml
@@ -4,5 +4,7 @@ parameters:
 services:
     ezpublish.fieldType.ezxmltext.externalStorage:
         class: "%ezpublish.fieldType.ezxmltext.externalStorage.class%"
+        arguments:
+            - "@ezpublish.fieldType.ezxmltext.storage_gateway"
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezxmltext}

--- a/lib/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/lib/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -4,6 +4,6 @@ parameters:
 services:
     ezpublish.fieldType.ezxmltext.storage_gateway:
         class: "%ezpublish.fieldType.ezxmltext.storage_gateway.class%"
-        arguments: ["@ezpublish.fieldType.ezurl.storage_gateway"]
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezxmltext, identifier: LegacyStorage}
+        arguments:
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.fieldType.ezurl.storage_gateway"

--- a/tests/lib/XmlTextSPIIntegrationTest.php
+++ b/tests/lib/XmlTextSPIIntegrationTest.php
@@ -66,8 +66,11 @@ class XmlTextSPIIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new XmlTextConverter(),
             new FieldType\XmlText\XmlTextStorage(
-                array(
-                    'LegacyStorage' => new LegacyStorage(new UrlGateway()),
+                new LegacyStorage(
+                    $this->getDatabaseHandler(),
+                    new UrlGateway(
+                        $this->getDatabaseHandler()
+                    )
                 )
             )
         );


### PR DESCRIPTION
This PR adds the new storage gateway API for field types introduced in https://github.com/ezsystems/ezpublish-kernel/pull/1985

Since this field type in its storage gateway uses `ezurl` storage gateway from eZ kernel, there's no sane way to keep backwards compatibility with previous versions of eZ kernel and the only way to fix the field type is to switch to the new API completely.

For that reason, this also bumps master to 1.3.