### PR TITLE
Updated PHPUnit to 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,36 +1,39 @@
 {
-  "name": "ezsystems/ezplatform-xmltext-fieldtype",
-  "description": "XmlText field type implementation for eZ Platform",
-  "license": "GPL-2.0",
-  "type": "ezplatform-bundle",
-  "authors": [
-    {
-      "name": "eZ dev-team & eZ Community",
-      "homepage": "https://github.com/ezsystems/ezplatform-xmltext-fieldtype/contributors"
+    "name": "ezsystems/ezplatform-xmltext-fieldtype",
+    "description": "XmlText field type implementation for eZ Platform",
+    "license": "GPL-2.0",
+    "type": "ezplatform-bundle",
+    "authors": [
+        {
+            "name": "eZ dev-team & eZ Community",
+            "homepage": "https://github.com/ezsystems/ezplatform-xmltext-fieldtype/contributors"
+        }
+    ],
+    "require": {
+        "ezsystems/ezpublish-kernel": "^6.11@dev"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7",
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0",
+        "ezsystems/ezplatform-solr-search-engine": "^1.0@dev,<1.3"
+    },
+    "autoload": {
+        "psr-4": {
+            "EzSystems\\EzPlatformXmlTextFieldTypeBundle\\": "bundle",
+            "eZ\\Publish\\Core\\FieldType\\XmlText\\": "lib/FieldType/XmlText",
+            "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\": "lib/Persistence/Legacy/Content/FieldValue/Converter",
+            "eZ\\Publish\\Core\\REST\\Common\\FieldTypeProcessor\\": "lib/REST/Common/FieldTypeProcessor"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "EzSystems\\EzPlatformXmlTextFieldTypeBundle\\Tests\\": "tests/bundle",
+            "EzSystems\\EzPlatformXmlTextFieldType\\Tests\\": "tests/lib"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.3.x-dev"
+        }
     }
-  ],
-  "require": {
-    "ezsystems/ezpublish-kernel": "^6.11@dev"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "~4.7",
-    "matthiasnoback/symfony-dependency-injection-test": "0.*",
-    "zendframework/zend-code": "~2.4.3",
-    "ezsystems/ezplatform-solr-search-engine": "^1.0@dev,<1.3"
-  },
-  "autoload": {
-    "psr-4": {
-      "EzSystems\\EzPlatformXmlTextFieldTypeBundle\\": "bundle",
-      "EzSystems\\EzPlatformXmlTextFieldTypeBundle\\Tests\\": "tests/bundle",
-      "eZ\\Publish\\Core\\FieldType\\XmlText\\": "lib/FieldType/XmlText",
-      "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter\\": "lib/Persistence/Legacy/Content/FieldValue/Converter",
-      "eZ\\Publish\\Core\\REST\\Common\\FieldTypeProcessor\\": "lib/REST/Common/FieldTypeProcessor",
-      "EzSystems\\EzPlatformXmlTextFieldType\\Tests\\": "tests/lib"
-    }
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "1.3.x-dev"
-    }
-  }
 }

--- a/tests/bundle/DependencyInjection/Compiler/XmlTextConverterPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/XmlTextConverterPassTest.php
@@ -36,7 +36,7 @@ class XmlTextConverterPassTest extends AbstractCompilerPassTestCase
         $this->assertSame(1, count($calls));
         list($method, $arguments) = $calls[0];
         $this->assertSame('addPreConverter', $method);
-        $this->assertInstanceOf('Symfony\\Component\\DependencyInjection\\Reference', $arguments[0]);
+        $this->assertInstanceOf(Reference::class, $arguments[0]);
         $this->assertSame('foo.converter', (string)$arguments[0]);
     }
 
@@ -71,12 +71,9 @@ class XmlTextConverterPassTest extends AbstractCompilerPassTestCase
     public function testSortConverterIds()
     {
         $container = new ContainerBuilder();
-        $html5ConvertDef = $this->getMock(
-            'Symfony\\Component\\DependencyInjection\\Definition',
-            array(
-                'addMethodCall',
-            )
-        );
+        $html5ConvertDef = $this->getMockBuilder(Definition::class)
+            ->setMethods(['addMethodCall'])
+            ->getMock();
         $container->setDefinition('ezpublish.fieldType.ezxmltext.converter.html5', $html5ConvertDef);
 
         $preConverterDef1 = new Definition();

--- a/tests/lib/FieldType/Converter/EmbedLinkingTest.php
+++ b/tests/lib/FieldType/Converter/EmbedLinkingTest.php
@@ -11,13 +11,13 @@
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Converter;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedLinking;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use DOMDocument;
 
 /**
  * Tests the EmbedLinking converter.
  */
-class EmbedLinkingTest extends PHPUnit_Framework_TestCase
+class EmbedLinkingTest extends TestCase
 {
     /**
      * Provider for conversion test.

--- a/tests/lib/FieldType/Converter/EmbedToHtml5Test.php
+++ b/tests/lib/FieldType/Converter/EmbedToHtml5Test.php
@@ -11,18 +11,26 @@
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Converter;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedToHtml5;
+use eZ\Publish\Core\Repository\LocationService;
+use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use PHPUnit\Framework\TestCase;
 use DOMDocument;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests the EmbedToHtml5 Preconverter
  * Class EmbedToHtml5Test.
  */
-class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
+class EmbedToHtml5Test extends TestCase
 {
     /**
      * @return array
@@ -589,9 +597,7 @@ ezlegacytmp-embed-link-node_id="222"
      */
     protected function getMockFragmentHandler()
     {
-        return $this->getMockBuilder('Symfony\\Component\\HttpKernel\\Fragment\\FragmentHandler')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(FragmentHandler::class);
     }
 
     /**
@@ -599,9 +605,7 @@ ezlegacytmp-embed-link-node_id="222"
      */
     protected function getMockContentService()
     {
-        return $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\ContentService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(ContentService::class);
     }
 
     /**
@@ -609,9 +613,7 @@ ezlegacytmp-embed-link-node_id="222"
      */
     protected function getMockLocationService()
     {
-        return $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\LocationService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(LocationService::class);
     }
 
     /**
@@ -619,7 +621,7 @@ ezlegacytmp-embed-link-node_id="222"
      */
     protected function getLoggerMock()
     {
-        return $this->getMock('Psr\\Log\\LoggerInterface');
+        return $this->createMock(LoggerInterface::class);
     }
 
     /**
@@ -630,11 +632,7 @@ ezlegacytmp-embed-link-node_id="222"
      */
     protected function getMockRepository($contentService, $locationService)
     {
-        $repositoryClass = 'eZ\\Publish\\Core\\Repository\\Repository';
-        $repository = $this
-            ->getMockBuilder($repositoryClass)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $repository = $this->createMock(Repository::class);
 
         $repository->expects($this->any())
             ->method('sudo')
@@ -672,13 +670,13 @@ ezlegacytmp-embed-link-node_id="222"
         $fragmentHandler = $this->getMockFragmentHandler();
         $contentService = $this->getMockContentService();
 
-        $versionInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfo = $this->createMock(APIVersionInfo::class);
         $versionInfo->expects($this->any())
             ->method('__get')
             ->with('status')
             ->will($this->returnValue($status));
 
-        $content = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
+        $content = $this->createMock(Content::class);
         $content->expects($this->any())
             ->method('getVersionInfo')
             ->will($this->returnValue($versionInfo));
@@ -721,7 +719,7 @@ ezlegacytmp-embed-link-node_id="222"
             $fragmentHandler,
             $repository,
             array('view', 'class', 'node_id', 'object_id'),
-            $this->getMock('Psr\\Log\\LoggerInterface')
+            $this->getLoggerMock()
         );
 
         $converter->convert($dom);
@@ -784,7 +782,7 @@ ezlegacytmp-embed-link-node_id="222"
             $fragmentHandler,
             $repository,
             array('view', 'class', 'node_id', 'object_id'),
-            $this->getMock('Psr\\Log\\LoggerInterface')
+            $this->getLoggerMock()
         );
 
         $converter->convert($dom);
@@ -857,13 +855,13 @@ ezlegacytmp-embed-link-node_id="222"
         $fragmentHandler = $this->getMockFragmentHandler();
         $contentService = $this->getMockContentService();
 
-        $versionInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfo = $this->createMock(APIVersionInfo::class);
         $versionInfo->expects($this->any())
             ->method('__get')
             ->with('status')
             ->will($this->returnValue(APIVersionInfo::STATUS_DRAFT));
 
-        $content = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
+        $content = $this->createMock(Content::class);
         $content->expects($this->any())
             ->method('getVersionInfo')
             ->will($this->returnValue($versionInfo));
@@ -892,7 +890,7 @@ ezlegacytmp-embed-link-node_id="222"
             $fragmentHandler,
             $repository,
             array('view', 'class', 'node_id', 'object_id'),
-            $this->getMock('Psr\\Log\\LoggerInterface')
+            $this->getLoggerMock()
         );
 
         $converter->convert($dom);
@@ -909,8 +907,8 @@ ezlegacytmp-embed-link-node_id="222"
         $fragmentHandler = $this->getMockFragmentHandler();
         $locationService = $this->getMockLocationService();
 
-        $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
-        $location = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $contentInfo = $this->createMock(ContentInfo::class);
+        $location = $this->createMock(APILocation::class);
         $location
             ->expects($this->exactly(2))
             ->method('getContentInfo')
@@ -939,7 +937,7 @@ ezlegacytmp-embed-link-node_id="222"
             $fragmentHandler,
             $repository,
             array('view', 'class', 'node_id', 'object_id'),
-            $this->getMock('Psr\\Log\\LoggerInterface')
+            $this->getLoggerMock()
         );
 
         $converter->convert($dom);
@@ -985,7 +983,7 @@ ezlegacytmp-embed-link-node_id="222"
             ->with($this->equalTo(42))
             ->will(
                 $this->throwException(
-                    $this->getMock('eZ\\Publish\\API\\Repository\\Exceptions\\NotFoundException')
+                    $this->createMock(NotFoundException::class)
                 )
             );
 
@@ -1053,7 +1051,7 @@ ezlegacytmp-embed-link-node_id="222"
             ->with($this->equalTo(42))
             ->will(
                 $this->throwException(
-                    $this->getMock('eZ\\Publish\\API\\Repository\\Exceptions\\NotFoundException')
+                    $this->createMock(NotFoundException::class)
                 )
             );
 
@@ -1105,13 +1103,13 @@ ezlegacytmp-embed-link-node_id="222"
         $fragmentHandler = $this->getMockFragmentHandler();
         $contentService = $this->getMockContentService();
 
-        $versionInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfo = $this->createMock(APIVersionInfo::class);
         $versionInfo->expects($this->any())
             ->method('__get')
             ->with('status')
             ->will($this->returnValue($status));
 
-        $content = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
+        $content = $this->createMock(Content::class);
         $content->expects($this->any())
             ->method('getVersionInfo')
             ->will($this->returnValue($versionInfo));
@@ -1144,7 +1142,7 @@ ezlegacytmp-embed-link-node_id="222"
             $fragmentHandler,
             $repository,
             array('view', 'class', 'node_id', 'object_id'),
-            $this->getMock('Psr\\Log\\LoggerInterface')
+            $this->getLoggerMock()
         );
 
         $converter->convert($dom);

--- a/tests/lib/FieldType/Converter/ExpandingTest.php
+++ b/tests/lib/FieldType/Converter/ExpandingTest.php
@@ -11,13 +11,13 @@
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Converter;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\Expanding;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use DOMDocument;
 
 /**
  * Tests the Expanding converter.
  */
-class ExpandingTest extends PHPUnit_Framework_TestCase
+class ExpandingTest extends TestCase
 {
     /**
      * Provider for conversion test.

--- a/tests/lib/FieldType/Converter/EzLinkToHtml5Test.php
+++ b/tests/lib/FieldType/Converter/EzLinkToHtml5Test.php
@@ -11,16 +11,24 @@
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Converter;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\EzLinkToHtml5;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException as APIUnauthorizedException;
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\Repository\LocationService;
+use eZ\Publish\Core\Repository\URLAliasService;
+use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use DOMXPath;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests the EzLinkToHtml5 Preconverter
  * Class EmbedToHtml5Test.
  */
-class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
+class EzLinkToHtml5Test extends TestCase
 {
     /**
      * @return array
@@ -288,9 +296,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
      */
     protected function getMockContentService()
     {
-        return $this->getMockBuilder('eZ\Publish\Core\Repository\ContentService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(ContentService::class);
     }
 
     /**
@@ -298,9 +304,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
      */
     protected function getMockLocationService()
     {
-        return $this->getMockBuilder('eZ\Publish\Core\Repository\LocationService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(LocationService::class);
     }
 
     /**
@@ -308,9 +312,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
      */
     protected function getMockURLAliasService()
     {
-        return $this->getMockBuilder('eZ\Publish\Core\Repository\URLAliasService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(URLAliasService::class);
     }
 
     /**
@@ -318,10 +320,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
      */
     protected function getMockUrlAliasRouter()
     {
-        return $this
-            ->getMockBuilder('eZ\\Publish\\Core\\MVC\\Symfony\\Routing\\UrlAliasRouter')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(UrlAliasRouter::class);
     }
 
     /**
@@ -332,7 +331,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
      */
     protected function getMockRepository($contentService, $locationService, $urlAliasService)
     {
-        $repository = $this->getMock('eZ\Publish\API\Repository\Repository');
+        $repository = $this->createMock(Repository::class);
 
         $repository->expects($this->any())
             ->method('getContentService')
@@ -409,7 +408,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
         $locationService = $this->getMockLocationService();
         $urlAliasRouter = $this->getMockUrlAliasRouter();
 
-        $location = $this->getMock('eZ\Publish\API\Repository\Values\Content\Location');
+        $location = $this->createMock(Location::class);
 
         $locationService->expects($this->once())
             ->method('loadLocation')
@@ -455,8 +454,8 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
         $locationService = $this->getMockLocationService();
         $urlAliasRouter = $this->getMockUrlAliasRouter();
 
-        $contentInfo = $this->getMock('eZ\Publish\API\Repository\Values\Content\ContentInfo');
-        $location = $this->getMock('eZ\Publish\API\Repository\Values\Content\Location');
+        $contentInfo = $this->createMock(ContentInfo::class);
+        $location = $this->createMock(Location::class);
 
         $contentInfo->expects($this->once())
             ->method('__get')
@@ -509,7 +508,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
         $contentService = $this->getMockContentService();
         $locationService = $this->getMockLocationService();
         $urlAliasRouter = $this->getMockUrlAliasRouter();
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock(LoggerInterface::class);
 
         $logger->expects($this->once())
             ->method($logType)
@@ -543,7 +542,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
         $contentService = $this->getMockContentService();
         $locationService = $this->getMockLocationService();
         $urlAliasRouter = $this->getMockUrlAliasRouter();
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock(LoggerInterface::class);
 
         $logger->expects($this->once())
             ->method($logType)

--- a/tests/lib/FieldType/Converter/Html5Test.php
+++ b/tests/lib/FieldType/Converter/Html5Test.php
@@ -13,7 +13,8 @@ namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Converter;
 use eZ\Publish\Core\FieldType\XmlText\Converter\Expanding;
 use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedLinking;
 use eZ\Publish\Core\FieldType\XmlText\Converter\Html5;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\FieldType\XmlText\Converter;
+use PHPUnit\Framework\TestCase;
 use DOMDocument;
 use DOMNodeList;
 use DOMXPath;
@@ -21,7 +22,7 @@ use DOMXPath;
 /**
  * Tests the Html5 converter.
  */
-class Html5Test extends PHPUnit_Framework_TestCase
+class Html5Test extends TestCase
 {
     protected $file;
 
@@ -41,7 +42,7 @@ class Html5Test extends PHPUnit_Framework_TestCase
 
     protected function getPreConvertMock()
     {
-        return $this->getMockBuilder('eZ\Publish\Core\FieldType\XmlText\Converter')
+        return $this->getMockBuilder(Converter::class)
             ->getMock();
     }
 

--- a/tests/lib/FieldType/Gateway/LegacyStorageTest.php
+++ b/tests/lib/FieldType/Gateway/LegacyStorageTest.php
@@ -13,26 +13,24 @@ namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Gateway;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\FieldType\XmlText\XmlTextStorage\Gateway\LegacyStorage;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the LegacyStorage
  * Class LegacyStorageTest.
  */
-class LegacyStorageTest extends PHPUnit_Framework_TestCase
+class LegacyStorageTest extends TestCase
 {
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\FieldType\XmlText\XmlTextStorage\Gateway\LegacyStorage
      */
     protected function getPartlyMockedLegacyStorage(array $testMethods = null)
     {
-        return $this->getMock(
-            'eZ\Publish\Core\FieldType\XmlText\XmlTextStorage\Gateway\LegacyStorage',
-            $testMethods,
-            array(),
-            '',
-            false
-        );
+        return $this->getMockBuilder(LegacyStorage::class)
+            ->disableOriginalConstructor()
+            ->setMethods($testMethods)
+            ->getMock();
     }
 
     /**

--- a/tests/lib/FieldType/Input/EzXmlTest.php
+++ b/tests/lib/FieldType/Input/EzXmlTest.php
@@ -11,10 +11,10 @@
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Input;
 
 use eZ\Publish\Core\FieldType\XmlText\Input\EzXml;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Exception;
 
-class EzXmlTest extends PHPUnit_Framework_TestCase
+class EzXmlTest extends TestCase
 {
     /**
      * @dataProvider providerForTestConvertCorrect

--- a/tests/lib/FieldType/XmlTextTest.php
+++ b/tests/lib/FieldType/XmlTextTest.php
@@ -13,16 +13,19 @@ namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType;
 use eZ\Publish\Core\FieldType\XmlText\Type as XmlTextType;
 use eZ\Publish\Core\FieldType\XmlText\Input\EzXml;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Persistence\TransformationProcessor;
 use eZ\Publish\API\Repository\Values\Content\Relation;
+use eZ\Publish\SPI\FieldType\ValidationError;
+use eZ\Publish\Core\FieldType\Value;
 use Exception;
 use DOMDocument;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group fieldType
  * @group ezxmltext
  */
-class XmlTextTest extends PHPUnit_Framework_TestCase
+class XmlTextTest extends TestCase
 {
     /**
      * Normally this should be enough:.
@@ -49,7 +52,7 @@ class XmlTextTest extends PHPUnit_Framework_TestCase
     protected function getTransformationProcessorMock()
     {
         return $this->getMockForAbstractClass(
-            'eZ\\Publish\\Core\\Persistence\\TransformationProcessor',
+            TransformationProcessor::class,
             array(),
             '',
             false,
@@ -135,7 +138,7 @@ class XmlTextTest extends PHPUnit_Framework_TestCase
 
         foreach ($validationResult as $actualResultElement) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\SPI\\FieldType\\ValidationError',
+                ValidationError::class,
                 $actualResultElement,
                 'Validation result of incorrect type.'
             );
@@ -148,7 +151,7 @@ class XmlTextTest extends PHPUnit_Framework_TestCase
      */
     public function testAcceptValueInvalidType()
     {
-        $this->getFieldType()->acceptValue($this->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Value')->disableOriginalConstructor()->getMock());
+        $this->getFieldType()->acceptValue($this->createMock(Value::class));
     }
 
     /**

--- a/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/XmlTextTest.php
+++ b/tests/lib/Persistence/Legacy/Content/FieldValue/Converter/XmlTextTest.php
@@ -13,7 +13,7 @@ namespace EzSystems\EzPlatformXmlTextFieldType\Tests\Persistence\Legacy\Content\
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test case for XmlText converter in Legacy storage.
@@ -21,7 +21,7 @@ use PHPUnit_Framework_TestCase;
  * @group fieldType
  * @group ezxmltext
  */
-class XmlTextTest extends PHPUnit_Framework_TestCase
+class XmlTextTest extends TestCase
 {
     /**
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter

--- a/tests/lib/REST/Common/FieldTypeProcessor/XmlTextProcessorTest.php
+++ b/tests/lib/REST/Common/FieldTypeProcessor/XmlTextProcessorTest.php
@@ -11,26 +11,23 @@
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\REST\Common\FieldTypeProcessor;
 
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor\XmlTextProcessor;
-use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\FieldType\XmlText\Type;
+use PHPUnit\Framework\TestCase;
 
-class XmlTextProcessorTest extends PHPUnit_Framework_TestCase
+class XmlTextProcessorTest extends TestCase
 {
-    protected $constants = array(
-        'TAG_PRESET_DEFAULT',
-        'TAG_PRESET_SIMPLE_FORMATTING',
-    );
-
     public function fieldSettingsHashes()
     {
-        return array_map(
-            function ($constantName) {
-                return array(
-                    array('tagPreset' => $constantName),
-                    array('tagPreset' => constant("eZ\\Publish\\Core\\FieldType\\XmlText\\Type::{$constantName}")),
-                );
-            },
-            $this->constants
-        );
+        return [
+            [
+                array('tagPreset' => 'TAG_PRESET_DEFAULT'),
+                array('tagPreset' => Type::TAG_PRESET_DEFAULT),
+            ],
+            [
+                array('tagPreset' => 'TAG_PRESET_SIMPLE_FORMATTING'),
+                array('tagPreset' => Type::TAG_PRESET_SIMPLE_FORMATTING),
+            ]
+        ];
     }
 
     /**

--- a/tests/lib/XmlTextAPIIntegrationTest.php
+++ b/tests/lib/XmlTextAPIIntegrationTest.php
@@ -18,6 +18,8 @@ use eZ\Publish\API\Repository\Values\Content\Field;
 use DOMDocument;
 use eZ\Publish\Core\Repository\Values\Content\Relation;
 use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use EzSystems\EzPlatformXmlTextFieldType\Tests\SetupFactory\LegacySetupFactory;
 
 /**
  * Integration test for use field type.
@@ -268,7 +270,7 @@ EOT
     public function assertFieldDataLoadedCorrect(Field $field)
     {
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\XmlText\\Value',
+            XmlTextValue::class,
             $field->value
         );
 
@@ -306,7 +308,7 @@ EOT
         return array(
             array(
                 new \stdClass(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentType',
+                InvalidArgumentType::class,
             ),
         );
     }
@@ -331,7 +333,7 @@ EOT
     public function assertUpdatedFieldDataLoadedCorrect(Field $field)
     {
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\XmlText\\Value',
+            XmlTextValue::class,
             $field->value
         );
 
@@ -380,7 +382,7 @@ EOT
     public function assertCopiedFieldDataLoadedCorrectly(Field $field)
     {
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\XmlText\\Value',
+            XmlTextValue::class,
             $field->value
         );
 
@@ -466,7 +468,7 @@ EOT
                 ->getFieldType($this->getTypeName())
                 ->fromHash($hash);
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\XmlText\\Value',
+            XmlTextValue::class,
             $xmlTextValue
         );
         $this->assertInstanceOf('DOMDocument', $xmlTextValue->xml);
@@ -566,7 +568,6 @@ EOT
         $repository = $this->getRepository();
 
         $contentService = $repository->getContentService();
-        $contentTypeService = $repository->getContentTypeService();
         $locationService = $repository->getLocationService();
 
         // Create test content type
@@ -614,7 +615,7 @@ EOT
 
     protected function checkSearchEngineSupport()
     {
-        if (ltrim(get_class($this->getSetupFactory()), '\\') === 'EzSystems\\EzPlatformXmlTextFieldType\\Tests\\SetupFactory\\LegacySetupFactory') {
+        if (ltrim(get_class($this->getSetupFactory()), '\\') === LegacySetupFactory::class) {
             $this->markTestSkipped(
                 "'ezxmltext' field type is not searchable with Legacy Search Engine"
             );


### PR DESCRIPTION
This PR resolves:
* PHPUnit updated to 5.7
* tests now extend namespaced `TestCase`
* removed deprecated `getMock()` method
* removed unused `zendframework\zend-code` dependency
* class constants used wherever possible
* tests autoloaded with `autoload-dev`
* `composer.json` now uses 4 space indent like on other repos