### PR TITLE
EZP-28174: Validation of ezobject:// and eznode:// links in the xml text field type

### DIFF
--- a/bundle/Resources/config/fieldtype_services.yml
+++ b/bundle/Resources/config/fieldtype_services.yml
@@ -6,6 +6,7 @@ parameters:
     ezpublish.fieldType.ezxmltext.converter.ezLinkToHtml5.class: eZ\Publish\Core\FieldType\XmlText\Converter\EzLinkToHtml5
     ezpublish.fieldType.ezxmltext.converter.expanding.class: eZ\Publish\Core\FieldType\XmlText\Converter\Expanding
     ezpublish.fieldType.ezxmltext.converter.embedLinking.class: eZ\Publish\Core\FieldType\XmlText\Converter\EmbedLinking
+    ezpublish.fieldType.ezxmltext.validator.internal_link.class: eZ\Publish\Core\FieldType\XmlText\InternalLinkValidator
 
 services:
     ezpublish.fieldType.ezxmltext.converter.html5:
@@ -44,3 +45,10 @@ services:
             - "@?logger"
         tags:
             - { name: ezpublish.ezxml.converter, priority: 8 }
+
+    ezpublish.fieldType.ezxmltext.validator.internal_link:
+        class: '%ezpublish.fieldType.ezxmltext.validator.internal_link.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.cache.contentHandler'
+            - '@ezpublish.spi.persistence.cache.locationHandler'
+

--- a/lib/FieldType/XmlText/InternalLinkValidator.php
+++ b/lib/FieldType/XmlText/InternalLinkValidator.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * File containing the eZ\Publish\Core\FieldType\XmlText\InternalLinkValidator class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\XmlText;
+
+use DOMDocument;
+use DOMXPath;
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
+/**
+ * Validator for XmlText internal format links.
+ */
+class InternalLinkValidator
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Handler
+     */
+    private $contentHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler;
+     */
+    private $locationHandler;
+
+    /**
+     * InternalLinkValidator constructor.
+     * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
+     */
+    public function __construct(ContentHandler $contentHandler, LocationHandler $locationHandler)
+    {
+        $this->contentHandler = $contentHandler;
+        $this->locationHandler = $locationHandler;
+    }
+
+    /**
+     * Extracts and validate internal links.
+     *
+     * @param \DOMDocument $xml
+     * @return array
+     */
+    public function validate(DOMDocument $xml)
+    {
+        $errors = [];
+
+        $xpath = new DOMXPath($xml);
+        foreach ($xpath->query('//link') as $link) {
+            if ($link->hasAttribute('object_id')) {
+                $objectId = $link->getAttribute('object_id');
+                if ($objectId && !$this->validateEzObject($objectId)) {
+                    $errors[] = $this->getInvalidLinkError('ezobject', $objectId, $link->getAttribute('anchor_name'));
+                }
+            } elseif ($link->hasAttribute('node_id')) {
+                $nodeId = $link->getAttribute('node_id');
+                if ($nodeId && !$this->validateEzNode($nodeId)) {
+                    $errors[] = $this->getInvalidLinkError('eznode', $nodeId, $link->getAttribute('anchor_name'));
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Validates link in "ezobject://" format.
+     *
+     * @param int $objectId
+     * @return bool
+     */
+    protected function validateEzObject($objectId)
+    {
+        try {
+            $this->contentHandler->loadContentInfo($objectId);
+        } catch (NotFoundException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates link in "eznode://" format.
+     *
+     * @param mixed $nodeId
+     * @return bool
+     */
+    protected function validateEzNode($nodeId)
+    {
+        try {
+            $this->locationHandler->load($nodeId);
+        } catch (NotFoundException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Builds error message for invalid url.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If given $scheme is not supported.
+     *
+     * @param string $scheme
+     * @param string $target
+     * @param null|string $anchorName
+     * @return string
+     */
+    protected function getInvalidLinkError($scheme, $target, $anchorName = null)
+    {
+        $url = "$scheme://$target" . ($anchorName ? '#' . $anchorName : '');
+
+        switch ($scheme) {
+            case 'eznode':
+                return sprintf('Invalid link "%s": target node cannot be found', $url);
+            case 'ezobject':
+                return sprintf('Invalid link "%s": target object cannot be found', $url);
+            default:
+                throw new InvalidArgumentException($scheme, "Given scheme '{$scheme}' is not supported.");
+        }
+    }
+}

--- a/lib/FieldType/XmlText/Type.php
+++ b/lib/FieldType/XmlText/Type.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\FieldType\XmlText;
 
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\FieldType\ValidationError;
@@ -37,6 +38,11 @@ class Type extends FieldType
     const TAG_PRESET_SIMPLE_FORMATTING = 1;
 
     /**
+     * @var null|\eZ\Publish\Core\FieldType\XmlText\InternalLinkValidator
+     */
+    protected $internalLinkValidator;
+
+    /**
      * List of settings available for this FieldType.
      *
      * The key is the setting name, and the value is the default value for this setting
@@ -53,6 +59,16 @@ class Type extends FieldType
             'default' => self::TAG_PRESET_DEFAULT,
         ),
     );
+
+    /**
+     * Type constructor.
+     *
+     * @param null|\eZ\Publish\Core\FieldType\XmlText\InternalLinkValidator $internalLinkValidator
+     */
+    public function __construct(InternalLinkValidator $internalLinkValidator = null)
+    {
+        $this->internalLinkValidator = $internalLinkValidator;
+    }
 
     /**
      * Returns the field type identifier for this field type.
@@ -243,6 +259,30 @@ class Type extends FieldType
     public function isSearchable()
     {
         return true;
+    }
+
+    /**
+     * Validates a field.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
+     * @param \eZ\Publish\Core\FieldType\XmlText\Value $value The field value for which an action is performed
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $value)
+    {
+        $validationErrors = array();
+
+        if ($this->internalLinkValidator !== null) {
+            $errors = $this->internalLinkValidator->validate($value->xml);
+            foreach ($errors as $error) {
+                $validationErrors[] = new ValidationError($error);
+            }
+        }
+
+        return $validationErrors;
     }
 
     /**

--- a/lib/settings/fieldtypes.yml
+++ b/lib/settings/fieldtypes.yml
@@ -5,5 +5,8 @@ services:
     ezpublish.fieldType.ezxmltext:
         class: "%ezpublish.fieldType.ezxmltext.class%"
         parent: ezpublish.fieldType
+        arguments:
+            - '@?ezpublish.fieldType.ezxmltext.validator.internal_link'
         tags:
             - {name: ezpublish.fieldType, alias: ezxmltext}
+

--- a/tests/lib/FieldType/InternalLinkValidatorTest.php
+++ b/tests/lib/FieldType/InternalLinkValidatorTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * File containing the eZ\Publish\Core\FieldType\XmlText\InternalLinkValidator class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType;
+
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
+use eZ\Publish\Core\FieldType\XmlText\InternalLinkValidator;
+use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+
+use PHPUnit\Framework\TestCase;
+
+class InternalLinkValidatorTest extends TestCase
+{
+    use PHPUnit5CompatTrait;
+
+    /** @var \eZ\Publish\SPI\Persistence\Content\Handler|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentHandler;
+    /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler|\PHPUnit_Framework_MockObject_MockObject */
+    private $locationHandler;
+
+    /**
+     * @before
+     */
+    public function setupInternalLinkValidator()
+    {
+        $this->contentHandler = $this->createMock(ContentHandler::class);
+        $this->locationHandler = $this->createMock(LocationHandler::class);
+    }
+
+    public function testValidateEzObjectExistingTarget()
+    {
+        $objectId = 2;
+
+        $this->contentHandler
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->with($objectId);
+
+        $validator = $this->getInternalLinkValidator();
+
+        $errors = $validator->validate($this->createInputDocument([
+            [
+                'scheme' => 'ezobject',
+                'target' => $objectId,
+                'anchor_name' => null
+            ]
+        ]));
+
+        $this->assertEmpty($errors);
+    }
+
+    /**
+     * @dataProvider getValidateEzObjectNonExistingTargetData
+     */
+    public function testValidateEzObjectNonExistingTarget($objectId, $anchorName)
+    {
+        $exception = $this->createMock(NotFoundException::class);
+
+        $this->contentHandler
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->with($objectId)
+            ->willThrowException($exception);
+
+        $validator = $this->getInternalLinkValidator();
+
+        $errors = $validator->validate($this->createInputDocument([
+            [
+                'scheme' => 'ezobject',
+                'target' => $objectId,
+                'anchor_name' => $anchorName
+            ]
+        ]));
+
+        $this->assertCount(1, $errors);
+        $this->assertContainsEzObjectInvalidLinkError($objectId, $anchorName, $errors);
+    }
+
+    public function getValidateEzObjectNonExistingTargetData()
+    {
+        return [
+            [
+                'objectId' => 2,
+                'anchorName' => null
+            ],
+            [
+                'objectId' => 2,
+                'anchorName' => 'anchor'
+            ],
+        ];
+    }
+
+    public function testValidateEzNodeExistingTarget()
+    {
+        $nodeId = 2;
+
+        $this->locationHandler
+            ->expects($this->once())
+            ->method('load')
+            ->with($nodeId);
+
+        $validator = $this->getInternalLinkValidator();
+
+        $errors = $validator->validate($this->createInputDocument([
+            [
+                'scheme' => 'eznode',
+                'target' => $nodeId,
+                'anchor_name' => null
+            ]
+        ]));
+
+        $this->assertEmpty($errors);
+    }
+
+    /**
+     * @dataProvider getValidateEzNodeNonExistingTargetData
+     */
+    public function testValidateEzNodeNonExistingTarget($nodeId , $anchorName)
+    {
+        $exception = $this->createMock(NotFoundException::class);
+        $this->locationHandler
+            ->expects($this->once())
+            ->method('load')
+            ->with($nodeId)
+            ->willThrowException($exception);
+
+        $validator = $this->getInternalLinkValidator();
+
+        $errors = $validator->validate($this->createInputDocument([
+            [
+                'scheme' => 'eznode',
+                'target' => $nodeId,
+                'anchor_name' => $anchorName
+            ]
+        ]));
+
+        $this->assertCount(1, $errors);
+        $this->assertContainsEzNodeInvalidLinkError($nodeId, $anchorName, $errors);
+    }
+
+    public function getValidateEzNodeNonExistingTargetData()
+    {
+        return [
+            [
+                'nodeId' => 2,
+                'anchorName' => null
+            ],
+            [
+                'nodeId' => 2,
+                'anchroName' => 'anchor'
+            ]
+        ];
+    }
+
+    private function assertContainsEzObjectInvalidLinkError($target, $anchorName, array $errors)
+    {
+        $format = 'Invalid link "ezobject://%s%s": target object cannot be found';
+
+        $this->assertContains(sprintf($format, $target, ($anchorName ? '#' . $anchorName : '')), $errors);
+    }
+
+    private function assertContainsEzNodeInvalidLinkError($target, $anchorName, array $errors)
+    {
+        $format = 'Invalid link "eznode://%s%s": target node cannot be found';
+
+        $this->assertContains(sprintf($format, $target, ($anchorName ? '#' . $anchorName : '')), $errors);
+    }
+
+    /**
+     * @return \eZ\Publish\Core\FieldType\XmlText\InternalLinkValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getInternalLinkValidator(array $methods = null)
+    {
+        return $this->getMockBuilder(InternalLinkValidator::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([
+                $this->contentHandler,
+                $this->locationHandler,
+            ])
+            ->getMock();
+    }
+
+    private function createInputDocument(array $urls = [])
+    {
+        $links = [];
+        foreach ($urls as $url) {
+            switch ($url['scheme']) {
+                case 'eznode':
+                    $links[] = $this->createEzNodeLink($url['target'], $url['anchor_name']);
+                    break;
+                case 'ezobject':
+                    $links[] = $this->creteEzObjectLink($url['target'], $url['anchor_name']);
+                    break;
+            }
+        }
+
+        $xml = '<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph>' . implode('', $links) . '</paragraph></section>';
+
+        $doc = new \DOMDocument();
+        $doc->loadXML($xml);
+        return $doc;
+    }
+
+    private function createEzNodeLink($id, $anchorName = null)
+    {
+        if (!$anchorName) {
+            return sprintf('<link node_id="%s">Link</link>', $id);
+        }
+
+        return sprintf('<link node_id="%s" anchor_name="%s">Link</link>', $id, $anchorName);
+    }
+
+    private function creteEzObjectLink($id, $anchorName = null)
+    {
+        if (!$anchorName) {
+            return sprintf('<link object_id="%s">Link</link>', $id);
+        }
+
+        return sprintf('<link object_id="%s" anchor_name="%s">Link</link>', $id, $anchorName);
+    }
+}
+


### PR DESCRIPTION
> JIRA:  https://jira.ez.no/browse/EZP-28174

## Description

This PR adds validation of `ezobject://` and `eznode://` links in the xml text field type. 

_This is follow up for ezsystems/ezpublish-legacy#1333 and ezsystems/ezpublish-kernel#2154_

## TODO: 
- [x] CS
- [x] Unit tests
- [x] Manual tests