### PR TITLE
EZP-28623: Display paragraph when user haven't permissions to see linked content

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -163,26 +163,33 @@
     </xsl:template>
 
     <xsl:template match="link">
-        <a>
-            <xsl:attribute name="href">
-                <xsl:value-of select="@url"/>
-            </xsl:attribute>
-            <xsl:attribute name="target">
-                <xsl:choose>
-                    <xsl:when test="@target">
-                        <xsl:value-of select="@target"/>
-                    </xsl:when>
-                    <xsl:otherwise>_self</xsl:otherwise>
-                </xsl:choose>
-            </xsl:attribute>
-            <xsl:if test="@xhtml:title">
-                <xsl:attribute name="title">
-                    <xsl:value-of select="@xhtml:title"/>
-                </xsl:attribute>
-            </xsl:if>
-            <xsl:copy-of select="@class"/>
-            <xsl:apply-templates/>
-        </a>
+        <xsl:choose>
+            <xsl:when test="@url">
+                <a>
+                    <xsl:attribute name="href">
+                        <xsl:value-of select="@url"/>
+                    </xsl:attribute>
+                    <xsl:attribute name="target">
+                        <xsl:choose>
+                            <xsl:when test="@target">
+                                <xsl:value-of select="@target"/>
+                            </xsl:when>
+                            <xsl:otherwise>_self</xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:attribute>
+                    <xsl:if test="@xhtml:title">
+                        <xsl:attribute name="title">
+                            <xsl:value-of select="@xhtml:title"/>
+                        </xsl:attribute>
+                    </xsl:if>
+                    <xsl:copy-of select="@class"/>
+                    <xsl:apply-templates/>
+                </a>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="embed">

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/014-link.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/014-link.xml
@@ -2,20 +2,10 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <a id="eztoc_1_1"/>
   <h2>Assorted array of links</h2>
-  <p>
-    <a href="" target="_blank" title="Anchor link title" class="linkClass1">Jump to content</a>
-  </p>
-  <p>
-    <a href="" target="_blank" title="Link title" class="linkClass2">Link text</a>
-  </p>
-  <p>
-    <a href="" target="_blank" title="Location title" class="linkClass3">Location content name</a>
-  </p>
-  <p>
-    <a href="" target="_blank" title="Location title 2" class="linkClass4">Location content name 2</a>
-  </p>
-  <p>
-    <a href="" target="_self" class="linkClass5" title="Content title">Content name</a>
-  </p>
+  <p>Jump to content</p>
+  <p>Link text</p>
+  <p>Location content name</p>
+  <p>Location content name 2</p>
+  <p>Content name</p>
   <p><a id="anchor"/>Some anchored content.</p>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/104-expandAndLinkEmbed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/104-expandAndLinkEmbed.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <p class="dire">
-    <a href="" target="_self">Hello </a>
-  </p>
+  <p class="dire">Hello </p>
   <div/>
-  <p class="dire">
-    <a href="" target="_self"> goodbye</a>
-  </p>
+  <p class="dire"> goodbye</p>
   <p class="fire">Hesperus entreats thy light, Goddess excellently bright.</p>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/105-expandAndLinkEmbedWrapped.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/105-expandAndLinkEmbedWrapped.xml
@@ -2,9 +2,9 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <p class="bass">Bless us then with wished sight</p>
   <p class="grass">
-    I<em>have<a href="" target="_self">no<strong>idea</strong></a></em></p>
+    I<em>haveno<strong>idea</strong></em></p>
   <div/>
-  <p class="grass"><em><a href="" target="_self"><strong>what is</strong>going</a>on</em>here
+  <p class="grass"><em><strong>what is</strong>goingon</em>here
   </p>
   <p class="sass">Thou who makes a day of night</p>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/106-expandAndLinkEmbedDoubleWrapped.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/106-expandAndLinkEmbedDoubleWrapped.xml
@@ -2,9 +2,9 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <p class="bass">When doubts and fears cause the tears that blind me.</p>
   <p>
-    Why<em>be<a href="" target="_self">dumb<strong>if you've</strong></a></em></p>
+    Why<em>bedumb<strong>if you've</strong></em></p>
   <div/>
-  <p><em><a href="" target="_self"><strong>come</strong>to</a>find</em>me?
+  <p><em><strong>come</strong>tofind</em>me?
   </p>
   <p class="sass">Speak to me and I'll follow, leaving all the world behind me.</p>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/107-expandAndLinkEmbedDoubleWrapped2.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/107-expandAndLinkEmbedDoubleWrapped2.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <p class="bass">Stormy weather turns to blue</p>
-  <p>
-    <a href="" target="_self">don't come in<strong>again like that,<strong>it isn't funny</strong></strong></a>
-  </p>
+  <p>don't come in<strong>again like that,<strong>it isn't funny</strong></strong></p>
   <div/>
-  <p>
-    <a href="" target="_self"><strong><strong>and I can pay</strong>someone else</strong>to make the orchestrations</a>
-  </p>
+  <p><strong><strong>and I can pay</strong>someone else</strong>to make the orchestrations</p>
   <p class="sass">Here's a song to take with you</p>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/109-expandEmbedInline.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/109-expandEmbedInline.xml
@@ -2,7 +2,7 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <p class="bass">When doubts and fears cause the tears that blind me.</p>
   <p>
-    Why<em>be<a href="" target="_self">dumb<strong>if you'vecome</strong>to</a>find</em>me?
+    Why<em>bedumb<strong>if you'vecome</strong>tofind</em>me?
   </p>
   <p class="sass">Speak to me and I'll follow, leaving all the world behind me.</p>
 </section>


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-28623

# Description
URL to the unaccessible linked content shouldn't be rendered as an anchor with empty `href` attribute. The whole anchor should be omitted, and only the wrapping paragraph should be rendered during the XML to HTML5 conversion.

  
  