### PR TITLE
Fixed EZP-29135 : Converting ezxmltext to richtext when embed tag contains neither node_id or object_id fails

### DIFF
--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -299,6 +299,19 @@ class RichText implements Converter
     }
 
     /**
+     * Check if $inputDocument has any embed|embed-inline tags without node_id or object_id.
+     * @param DOMDocument $inputDocument
+     */
+    protected function checkEmptyEmbedTags(DOMDocument $inputDocument)
+    {
+        $xpath = new DOMXPath($inputDocument);
+        $nodes = $xpath->query('//embed[not(@node_id|@object_id)] | //embed-inline[not(@node_id|@object_id)]');
+        if ($nodes->length > 0) {
+            $this->logger->warning('Warning: ezxmltext for contentobject_attribute.id=' . $this->currentContentFieldId . 'contains embed or embed-inline tag(s) without node_id or object_id');
+        }
+    }
+
+    /**
      * Before calling this function, make sure you are logged in as admin, or at least have access to all the objects
      * being embedded in the $inputDocument.
      *
@@ -311,6 +324,7 @@ class RichText implements Converter
     {
         $this->removeComments($inputDocument);
 
+        $this->checkEmptyEmbedTags($inputDocument);
         $convertedDocument = $this->getConverter()->convert($inputDocument);
         if ($checkDuplicateIds) {
             $this->reportNonUniqueIds($convertedDocument, $contentFieldId);

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/121-embed-no_idref.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/121-embed-no_idref.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+        <embed view="embed" size="original" align="right" />
+        <embed view="embed" size="original" align="right" node_id="128"/>
+        <embed view="embed" size="original" align="right" object_id="128"/>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/132-embed-inline-no_idref.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/132-embed-inline-no_idref.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+        <embed-inline view="embed" size="original" align="right" />
+        <embed-inline view="embed" size="original" align="right" node_id="128"/>
+        <embed-inline view="embed" size="original" align="right" object_id="128"/>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/121-embed-no_idref.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/121-embed-no_idref.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <ezembed view="embed" ezxhtml:align="right" ezxhtml:class="ez-embed-type-image" xlink:href="ezlocation://128">
+        <ezconfig>
+            <ezvalue key="size">original</ezvalue>
+        </ezconfig>
+    </ezembed>
+    <ezembed view="embed" ezxhtml:align="right" xlink:href="ezcontent://128">
+        <ezconfig>
+            <ezvalue key="size">original</ezvalue>
+        </ezconfig>
+    </ezembed>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/132-embed-inline-no_idref.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/132-embed-inline-no_idref.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>
+        <ezembedinline view="embed" ezxhtml:class="ez-embed-type-image" ezxhtml:align="right" xlink:href="ezlocation://128">
+            <ezconfig>
+                <ezvalue key="size">original</ezvalue>
+            </ezconfig>
+        </ezembedinline>
+        <ezembedinline view="embed" ezxhtml:align="right" xlink:href="ezcontent://128">
+            <ezconfig>
+                <ezvalue key="size">original</ezvalue>
+            </ezconfig>
+        </ezembedinline>
+    </para>
+</section>


### PR DESCRIPTION
Outputs warning if ezxmltext contains `<embed>` or `<embed-inline>` tags which do not have `node_id=...` or `object_id=...` attributes

~Depends on [this kernel fix](https://github.com/ezsystems/ezpublish-kernel/pull/2320)~. No longer correct due to https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/46

Note : One test is failing.. That test is fixed in an separate PR (which for now have been merged to wrong branch)