### PR TITLE
EZP-29258 Convertion of Embeds with links from ezxmltext to richtext is broken

### DIFF
--- a/lib/FieldType/XmlText/Converter/EmbedLinking.php
+++ b/lib/FieldType/XmlText/Converter/EmbedLinking.php
@@ -90,6 +90,10 @@ class EmbedLinking implements Converter
         if ($link->hasAttribute('url')) {
             $embed->setAttribute(static::TEMP_PREFIX . 'url', $link->getAttribute('url'));
         }
+
+        if ($link->hasAttribute('url_id')) {
+            $embed->setAttribute(static::TEMP_PREFIX . 'url_id', $link->getAttribute('url_id'));
+        }
     }
 
     /**

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/001-embedUrlLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/001-embedUrlLink.xml
@@ -2,7 +2,7 @@
 <section xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
          xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
-  <link url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
+  <link url_id="72" url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
     <embed view="embed" size="medium" custom:offset="0" custom:limit="5" object_id="110"/>
   </link>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/004-inlineEmbedUrlLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/004-inlineEmbedUrlLink.xml
@@ -4,7 +4,7 @@
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph>
     Look!
-    <link url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
+    <link url_id="72" url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
       <embed-inline view="embed" size="medium" custom:offset="0" custom:limit="5" object_id="110"/>
     </link>
     It's an embed!

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/006-inlineEmbedContentLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/006-inlineEmbedContentLink.xml
@@ -4,7 +4,7 @@
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph>
     An embed again...
-    <link anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
+    <link url_id="72" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
       <embed-inline view="embed" size="medium" custom:offset="0" custom:limit="5" object_id="110"/>
     </link>
   </paragraph>

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/007-inlineEmbedUrlLinkMixed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/input/007-inlineEmbedUrlLinkMixed.xml
@@ -4,7 +4,7 @@
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph>
     Yawn...
-    <link url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
+    <link url_id="72" url="http://www.hr" anchor_name="fragment" target="_blank" xhtml:title="title" class="class" xhtml:id="id">
       <embed-inline view="embed" size="medium" custom:offset="0" custom:limit="5" object_id="110"/>
       another embed...
     </link>

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/001-embedUrlLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/001-embedUrlLink.xml
@@ -8,6 +8,7 @@
       custom:offset="0"
       custom:limit="5"
       object_id="110"
+      ezlegacytmp-embed-link-url_id="72"
       ezlegacytmp-embed-link-url="http://www.hr"
       ezlegacytmp-embed-link-anchor_name="fragment"
       ezlegacytmp-embed-link-target="_blank"

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/004-inlineEmbedUrlLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/004-inlineEmbedUrlLink.xml
@@ -11,6 +11,7 @@
         ezlegacytmp-embed-link-target="_blank"
         ezlegacytmp-embed-link-title="title"
         ezlegacytmp-embed-link-url="http://www.hr"
+        ezlegacytmp-embed-link-url_id="72"
         object_id="110"
         size="medium"
         view="embed"

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/006-inlineEmbedContentLink.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/006-inlineEmbedContentLink.xml
@@ -8,6 +8,7 @@
         ezlegacytmp-embed-link-anchor_name="fragment"
         ezlegacytmp-embed-link-class="class"
         ezlegacytmp-embed-link-id="id"
+        ezlegacytmp-embed-link-url_id="72"
         ezlegacytmp-embed-link-target="_blank"
         ezlegacytmp-embed-link-title="title"
         object_id="110"

--- a/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/007-inlineEmbedUrlLinkMixed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/embed_linking/output/007-inlineEmbedUrlLinkMixed.xml
@@ -4,13 +4,14 @@
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph>
     Yawn...
-    <link anchor_name="fragment" class="class" target="_blank" url="http://www.hr" xhtml:id="id" xhtml:title="title"><embed-inline
+    <link anchor_name="fragment" class="class" target="_blank" url="http://www.hr" url_id="72" xhtml:id="id" xhtml:title="title"><embed-inline
         ezlegacytmp-embed-link-anchor_name="fragment"
         ezlegacytmp-embed-link-class="class"
         ezlegacytmp-embed-link-id="id"
         ezlegacytmp-embed-link-target="_blank"
         ezlegacytmp-embed-link-title="title"
         ezlegacytmp-embed-link-url="http://www.hr"
+        ezlegacytmp-embed-link-url_id="72"
         object_id="110"
         size="medium"
         view="embed" custom:limit="5"


### PR DESCRIPTION
This fixes a regression caused by [EZP-26962](https://jira.ez.no/browse/EZP-26962) and https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/17

After the fix of EZP-26962, the attribute `ezlegacytmp-embed-link-url_id` is no more used by the ezxmltext -> xhtml conversion, but it is still used by ezxmltext -> richtext