### PR TITLE
Removed extra <para> when converting custom tag from ezxmltext to richtext

### DIFF
--- a/lib/FieldType/XmlText/Converter/ExpandingToRichText.php
+++ b/lib/FieldType/XmlText/Converter/ExpandingToRichText.php
@@ -55,7 +55,7 @@ class ExpandingToRichText extends Expanding
 
     protected function containsCustomTag(DOMElement $paragraph)
     {
-        //Safty pin; Custom tags are block elements and should be the only element inside the paragraph
+        //Safety pin; Custom tags should be the only element inside the paragraph
         // Also, paragraph might be empty...
         if ($paragraph->childNodes->length !== 1) {
             return false;
@@ -63,5 +63,6 @@ class ExpandingToRichText extends Expanding
         if ($paragraph->childNodes->item(0)->localName === 'custom') {
             return true;
         }
+        return false;
     }
 }

--- a/lib/FieldType/XmlText/Converter/ExpandingToRichText.php
+++ b/lib/FieldType/XmlText/Converter/ExpandingToRichText.php
@@ -38,8 +38,6 @@ class ExpandingToRichText extends Expanding
      * Checks whether a paragraph can be considered as temporary and can then be
      * ignored later.
      *
-     * Note : I believe this one could always return false unless when isEmpty() when converting to richtext, but leaving as-is for now.
-     *
      * @param \DOMElement $paragraph
      * @return bool
      */
@@ -49,8 +47,21 @@ class ExpandingToRichText extends Expanding
             $paragraph->hasAttribute('xmlns:tmp')
             && (
                 $this->containsBlock($paragraph)
+                || $this->containsCustomTag($paragraph)
                 || $this->isEmpty($paragraph)
             )
             ;
+    }
+
+    protected function containsCustomTag(DOMElement $paragraph)
+    {
+        //Safty pin; Custom tags are block elements and should be the only element inside the paragraph
+        // Also, paragraph might be empty...
+        if ($paragraph->childNodes->length !== 1) {
+            return false;
+        }
+        if ($paragraph->childNodes->item(0)->localName === 'custom') {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
The test [`EzxmlToDocbookTest::testConvert#23`](https://github.com/ezsystems/ezpublish-kernel/commit/3a6a6ec078fc23faab95aebb50da1eff97861919#diff-429a392f5d946a60380b9ac60dae0693R8) in kernel is failing : 

```diff
1) eZ\Publish\Core\FieldType\Tests\RichText\Converter\Xslt\EzxmlToDocbookTest::testConvert with data set #23 ('/var/www/external/ezpublish-k...te.xml', '/var/www/external/ezpublish-k...te.xml')
Failed asserting that two DOM documents are equal.
Input file: /var/www/external/ezpublish-kernel/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/ezxml/024-template.xml
Output file /var/www/external/ezpublish-kernel/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/024-template.xml
Failed asserting that two DOM documents are equal.
--- Expected
+++ Actual
@@ @@
       <ezvalue key="title">factoids</ezvalue>
     </ezconfig>
   </eztemplate>
-  <eztemplate name="externalimage" ezxhtml:align="right" ezxhtml:class="templateclass2">
-    <ezconfig>
-      <ezvalue key="src">http://upload.wikimedia.org/wikipedia/commons/c/c6/r-s_mk2.gif</ezvalue>
-      <ezvalue key="height">365</ezvalue>
-      <ezvalue key="width">500</ezvalue>
-      <ezvalue key="alt">flip-flop</ezvalue>
-      <ezvalue key="caption">bistable multivibrator</ezvalue>
-    </ezconfig>
-  </eztemplate>
-  <eztemplate name="factoidbox" ezxhtml:align="center" ezxhtml:class="templateclass3">
-    <ezcontent>it is widely known that the bistable multivibrator hums z's in the middle octave key of e.</ezcontent>
-  </eztemplate>
-  <eztemplate name="factoidbox" ezxhtml:align="center" ezxhtml:class="templateclass4"/>
+  <para>
+    <eztemplateinline name="externalimage" ezxhtml:align="right" ezxhtml:class="templateclass2">
+      <ezconfig>
+        <ezvalue key="align">right</ezvalue>
+        <ezvalue key="src">http://upload.wikimedia.org/wikipedia/commons/c/c6/r-s_mk2.gif</ezvalue>
+        <ezvalue key="height">365</ezvalue>
+        <ezvalue key="width">500</ezvalue>
+        <ezvalue key="alt">flip-flop</ezvalue>
+        <ezvalue key="caption">bistable multivibrator</ezvalue>
+      </ezconfig>
+    </eztemplateinline>
+  </para>
+  <para>
+    <eztemplateinline name="factoidbox" ezxhtml:align="center" ezxhtml:class="templateclass3">
+      <ezcontent>it is widely known that the bistable multivibrator hums z's in the middle octave key of e.</ezcontent>
+      <ezconfig>
+        <ezvalue key="align">center</ezvalue>
+      </ezconfig>
+    </eztemplateinline>
+  </para>
+  <para>
+    <eztemplateinline name="factoidbox" ezxhtml:align="center" ezxhtml:class="templateclass4">
+      <ezconfig>
+        <ezvalue key="align">center</ezvalue>
+      </ezconfig>
+    </eztemplateinline>
+  </para>
 </section>
```

As you can see, there is a extra `<para>` in the result. I believe this is a regression of https://github.com/ezsystems/ezplatform-xmltext-fieldtype/commit/1b10190bb7766327276ab60bdf381d6807c953e2 / https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/5


Note: This PR is currently based on temporary_para. It should be rebased on master before merge