### PR TITLE
EZP-29267: Convertion of links with href from ezxmltext to richtext is not supported

### DIFF
--- a/lib/FieldType/XmlText/Converter/ExpandingToRichText.php
+++ b/lib/FieldType/XmlText/Converter/ExpandingToRichText.php
@@ -63,6 +63,7 @@ class ExpandingToRichText extends Expanding
         if ($paragraph->childNodes->item(0)->localName === 'custom') {
             return true;
         }
+
         return false;
     }
 }

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -265,9 +265,14 @@
           <xsl:value-of select="concat( '#', @anchor_name )"/>
         </xsl:attribute>
       </xsl:when>
+      <xsl:when test="@href">
+        <xsl:attribute name="xlink:href">
+          <xsl:value-of select="concat( '', @href )"/>
+        </xsl:attribute>
+      </xsl:when>
       <xsl:otherwise>
         <xsl:message terminate="yes">
-          Unhandled link typeccc
+          Unhandled link type
         </xsl:message>
       </xsl:otherwise>
     </xsl:choose>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/041-link_href.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/041-link_href.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>
+        <strong>a link to
+            <link href="http://ez.no/" target="_blank">eZ</link>
+        </strong>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/041-link_href.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/041-link_href.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
+  <para>
+    <emphasis role="strong">a link to
+            <link xlink:href="http://ez.no/" xlink:show="new">eZ</link>
+        </emphasis>
+  </para>
+</section>


### PR DESCRIPTION
Handling of tags in format <link href="http://foobar.com" ...> is missing in xsl stylesheet
