### PR TITLE
EZP-29289: Migrating ezxmltext with invalid name or id attributes

### DIFF
--- a/bundle/Command/ConvertXmlTextToRichTextCommand.php
+++ b/bundle/Command/ConvertXmlTextToRichTextCommand.php
@@ -64,7 +64,13 @@ EOT
                 'disable-duplicate-id-check',
                 null,
                 InputOption::VALUE_NONE,
-                'Disable the check for duplicate html ids in every attribute. This might increase execution time on large databases'
+                'Disable the check for duplicate html ids in every attribute. This might decrease execution time on large databases'
+            )
+            ->addOption(
+                'disable-id-value-check',
+                null,
+                InputOption::VALUE_NONE,
+                'Disable the check for non-validating id/name values. This might decrease execution time on large databases'
             )
             ->addOption(
                 'test-content-object',
@@ -123,7 +129,7 @@ EOT
             $dryRun = true;
         }
 
-        $this->convertFields($dryRun, $testContentId, !$input->getOption('disable-duplicate-id-check'), $output);
+        $this->convertFields($dryRun, $testContentId, !$input->getOption('disable-duplicate-id-check'), !$input->getOption('disable-id-value-check'), $output);
     }
 
     protected function getContentTypeIds($contentTypeIdentifiers)
@@ -330,7 +336,7 @@ EOT
         }
     }
 
-    protected function convertFields($dryRun, $contentId, $checkDuplicateIds, OutputInterface $output)
+    protected function convertFields($dryRun, $contentId, $checkDuplicateIds, $checkIdValues, OutputInterface $output)
     {
         $count = $this->getRowCountOfContentObjectAttributes('ezxmltext', $contentId);
 
@@ -345,7 +351,7 @@ EOT
                 $inputValue = $row['data_text'];
             }
 
-            $converted = $this->converter->convert($this->createDocument($inputValue), $checkDuplicateIds, $row['id']);
+            $converted = $this->converter->convert($this->createDocument($inputValue), $checkDuplicateIds, $checkIdValues, $row['id']);
 
             $this->updateFieldRow($dryRun, $row['id'], $row['version'], $converted);
 

--- a/tests/lib/FieldType/Converter/RichTextTest.php
+++ b/tests/lib/FieldType/Converter/RichTextTest.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use Psr\Log\NullLogger;
 
 class RichTextTest extends TestCase
 {
@@ -54,8 +55,12 @@ class RichTextTest extends TestCase
         foreach (glob(__DIR__ . '/_fixtures/richtext/input/*.xml') as $inputFilePath) {
             $basename = basename($inputFilePath, '.xml');
             $outputFilePath = __DIR__ . "/_fixtures/richtext/output/{$basename}.xml";
+            $logFilePath = __DIR__ . "/_fixtures/richtext/log/{$basename}.log";
+            if (!file_exists($logFilePath)) {
+                $logFilePath = null;
+            }
 
-            $map[] = [$inputFilePath, $outputFilePath];
+            $map[] = [$inputFilePath, $outputFilePath, $logFilePath];
         }
 
         return $map;
@@ -123,18 +128,55 @@ class RichTextTest extends TestCase
         return $apiRepositoryStub;
     }
 
+    private function createLoggerStub($logFilePath)
+    {
+        $loggerStub = $this->createMock(NullLogger::class);
+
+        if ($logFilePath !== null) {
+            $log = file_get_contents($logFilePath);
+            $logLines = explode("\n", $log);
+            $logNo = 0;
+            foreach ($logLines as $expectedLogLine) {
+                if ($expectedLogLine === '') {
+                    continue;
+                }
+                if (strpos($expectedLogLine, '*') !== false) {
+                    $loggerStub->expects($this->at($logNo++))
+                        ->method('warning')
+                    ->with($this->callback(function ($logMessage) use ($expectedLogLine) {
+                        $expectedLogMessage = substr($expectedLogLine, 0, strpos($expectedLogLine, '*'));
+
+                        $this->assertEquals($expectedLogMessage, substr($logMessage, 0, strlen($expectedLogMessage)), 'Actual log message do not match the expected one');
+
+                        return true;
+                    }));
+                } else {
+                    $loggerStub->expects($this->at($logNo++))
+                        ->method('warning')
+                        ->with($expectedLogLine);
+                }
+            }
+        } else {
+            $loggerStub->expects($this->never())
+                ->method('warning');
+        }
+
+        return $loggerStub;
+    }
+
     /**
      * @param string $inputFilePath
      * @param string $outputFilePath
      *
      * @dataProvider providerForTestConvert
      */
-    public function testConvert($inputFilePath, $outputFilePath)
+    public function testConvert($inputFilePath, $outputFilePath, $logFilePath)
     {
         $apiRepositoryStub = $this->createApiRepositoryStub();
+        $loggerStub = $this->createLoggerStub($logFilePath);
 
         $inputDocument = $this->createDocument($inputFilePath);
-        $richText = new RichText($apiRepositoryStub);
+        $richText = new RichText($apiRepositoryStub, $loggerStub);
         $richText->setImageContentTypes([27]);
 
         $result = $richText->convert($inputDocument, true, true);

--- a/tests/lib/FieldType/Converter/RichTextTest.php
+++ b/tests/lib/FieldType/Converter/RichTextTest.php
@@ -137,7 +137,7 @@ class RichTextTest extends TestCase
         $richText = new RichText($apiRepositoryStub);
         $richText->setImageContentTypes([27]);
 
-        $result = $richText->convert($inputDocument, true);
+        $result = $richText->convert($inputDocument, true, true);
 
         $convertedDocument = $this->createDocument($result, false);
         $expectedDocument = $this->createDocument($outputFilePath);

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/041-anchor_invalid_id.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/041-anchor_invalid_id.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph align="justify">Here is an anchor
+        <anchor name="1name"/>
+    </paragraph>
+    <paragraph align="justify">Here is an anchor
+        <anchor name="n1ame"/>
+    </paragraph>
+    <paragraph align="justify">Here is an anchor
+        <anchor name="-1name"/>
+    </paragraph>
+    <paragraph align="justify">Here is an anchor
+        <anchor name="_name"/>
+    </paragraph>
+    <paragraph align="justify">Here is an anchor
+        <anchor name="aname"/>
+    </paragraph>
+    <paragraph align="justify">Here is an anchor
+        <anchor name="#aname"/>
+    </paragraph>
+    <paragraph align="justify">Here is an anchor
+        <anchor name="a@name"/>
+    </paragraph>
+    <paragraph align="justify">Here is an anchor
+        <anchor name="an£ame"/>
+    </paragraph>
+    <paragraph align="justify">Here is an anchor
+        <anchor name="aname["/>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/001-dupid-title.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/001-dupid-title.log
@@ -1,0 +1,2 @@
+Duplicated id in original ezxmltext for contentobject_attribute.id=[unknown], automatically generated new id : inv5 --> duplicated_id_inv5_*
+Duplicated id in original ezxmltext for contentobject_attribute.id=[unknown], automatically generated new id : inv5 --> duplicated_id_inv5_*

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/002-dupid-embed.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/002-dupid-embed.log
@@ -1,0 +1,1 @@
+Duplicated id in original ezxmltext for contentobject_attribute.id=[unknown], automatically generated new id : myembed_id --> duplicated_id_myembed_id_idm*

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/003-dupid-anchor.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/003-dupid-anchor.log
@@ -1,0 +1,1 @@
+Duplicated id in original ezxmltext for contentobject_attribute.id=[unknown], automatically generated new id : anchor --> duplicated_id_anchor_idm*

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/041-anchor_invalid_id.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/041-anchor_invalid_id.log
@@ -1,0 +1,6 @@
+Replaced non-validating id value in richtext for contentobject_attribute.id=[unknown], changed from : 1name --> rewrite_1name
+Replaced non-validating id value in richtext for contentobject_attribute.id=[unknown], changed from : -1name --> rewrite_-1name
+Replaced non-validating id value in richtext for contentobject_attribute.id=[unknown], changed from : #aname --> rewrite__aname
+Replaced non-validating id value in richtext for contentobject_attribute.id=[unknown], changed from : a@name --> rewrite_a_name
+Replaced non-validating id value in richtext for contentobject_attribute.id=[unknown], changed from : an£ame --> rewrite_an__ame
+Replaced non-validating id value in richtext for contentobject_attribute.id=[unknown], changed from : aname[ --> rewrite_aname_

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/121-embed-no_idref.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/121-embed-no_idref.log
@@ -1,0 +1,1 @@
+Warning: ezxmltext for contentobject_attribute.id=contains embed or embed-inline tag(s) without node_id or object_id

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/132-embed-inline-no_idref.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/132-embed-inline-no_idref.log
@@ -1,0 +1,1 @@
+Warning: ezxmltext for contentobject_attribute.id=contains embed or embed-inline tag(s) without node_id or object_id

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/041-anchor_invalid_id.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/041-anchor_invalid_id.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="rewrite_1name"/>
+    </para>
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="n1ame"/>
+    </para>
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="rewrite_-1name"/>
+    </para>
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="_name"/>
+    </para>
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="aname"/>
+    </para>
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="rewrite__aname"/>
+    </para>
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="rewrite_a_name"/>
+    </para>
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="rewrite_an__ame"/>
+    </para>
+    <para ezxhtml:textalign="justify">Here is an anchor
+        <anchor xml:id="rewrite_aname_"/>
+    </para>
+</section>


### PR DESCRIPTION
This PR fixes [EZP-29289](https://jira.ez.no/browse/EZP-29289)

It is not 100% bulletproof though;
 - ~It checks if first character in the attribute's value is white listed. It does not check the remaining characters. It would be possible to fix that, but it would require yet another XPath pass I believe.~
 -  Also, the whitelist may not be 100% complete

But I think this is good enought for now
