### PR TITLE
Added multiconcurrency support in ezxmltext convert command

### DIFF
--- a/bundle/Command/ConvertXmlTextToRichTextCommand.php
+++ b/bundle/Command/ConvertXmlTextToRichTextCommand.php
@@ -176,7 +176,7 @@ EOT
         }
         $imageContentTypeIds = $this->getContentTypeIds($this->imageContentTypeIdentifiers);
         if (count($imageContentTypeIds) !== count($this->imageContentTypeIdentifiers)) {
-            throw new RuntimeException('Unable to lookup all content type identifiers, found : ' . implode(',', $imageContentTypeIds));
+            throw new RuntimeException('Unable to lookup all content type identifiers, not found : ' . implode(',', array_diff($this->imageContentTypeIdentifiers, array_keys($imageContentTypeIds))));
         }
         $this->converter->setImageContentTypes($imageContentTypeIds);
     }
@@ -185,7 +185,7 @@ EOT
     {
         $query = $this->dbal->createQueryBuilder();
 
-        $query->select('c.id')
+        $query->select('c.identifier, c.id')
             ->from('ezcontentclass', 'c')
             ->where(
                 $query->expr()->in(
@@ -197,7 +197,7 @@ EOT
 
         $statement = $query->execute();
 
-        return $statement->fetchAll(PDO::FETCH_COLUMN);
+        return array_map('reset', $statement->fetchAll(PDO::FETCH_GROUP | PDO::FETCH_COLUMN));
     }
 
     protected function loginAsAdmin()

--- a/bundle/Command/ConvertXmlTextToRichTextCommandSubProcess.php
+++ b/bundle/Command/ConvertXmlTextToRichTextCommandSubProcess.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformXmlTextFieldTypeBundle\Command;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use eZ\Publish\Core\FieldType\XmlText\Value;
+
+class ConvertXmlTextToRichTextCommandSubProcess extends ConvertXmlTextToRichTextCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+        $this
+            ->setName('ezxmltext:convert-to-richtext-sub-process')
+            ->setDescription('internal command used by ezxmltext:convert-to-richtext')
+            ->setHidden(true)
+            ->addOption(
+                'offset',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Offset'
+            )
+            ->addOption(
+                'limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Limit'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->baseExecute($input, $output, $dryRun);
+
+        $offset = $input->getOption('offset');
+        $limit = $input->getOption('limit');
+
+        $this->convertFields($dryRun, null, !$input->getOption('disable-duplicate-id-check'), !$input->getOption('disable-id-value-check'), $offset, $limit);
+    }
+}

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -7,12 +7,18 @@ services:
         tags:
             - { name: ezpublish_rest.field_type_processor, alias: ezxmltext }
 
-    ezxmltext.command.convert_to_richtexst:
+    ezxmltext.command.convert_to_richtext:
         class: EzSystems\EzPlatformXmlTextFieldTypeBundle\Command\ConvertXmlTextToRichTextCommand
         arguments:
             - "@ezpublish.persistence.connection"
             - "@ezxmltext.richtext_converter"
             - "@?logger"
+        tags:
+            -  { name: console.command }
+
+    ezxmltext.command.convert_to_richtext_sub_process:
+        class: EzSystems\EzPlatformXmlTextFieldTypeBundle\Command\ConvertXmlTextToRichTextCommandSubProcess
+        parent: ezxmltext.command.convert_to_richtext
         tags:
             -  { name: console.command }
 

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -362,7 +362,15 @@ class RichText implements Converter
         $this->removeComments($inputDocument);
 
         $this->checkEmptyEmbedTags($inputDocument);
-        $convertedDocument = $this->getConverter()->convert($inputDocument);
+        try {
+            $convertedDocument = $this->getConverter()->convert($inputDocument);
+        } catch (\Exception $e) {
+            $this->logger->error(
+                "Unable to convert ezmltext for contentobject_attribute.id=$contentFieldId",
+                ['errors' => $e->getMessage()]
+            );
+            throw $e;
+        }
         if ($checkDuplicateIds) {
             $this->reportNonUniqueIds($convertedDocument, $contentFieldId);
         }


### PR DESCRIPTION
This PR adds `--concurrency=...` option to ezxmltext conversion command. This will speed up conversion on multi core hardware.

Also, the conversion script no longer loads the whole `ezcontentobject_attribute` table into memory at launch....