### PR TITLE
Fix  EZP-29339: ezxmltext -> ricktext conversion : links with object_remote_id="..." not suppor

### DIFF
--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -376,6 +376,18 @@ class RichText implements Converter
                 continue;
             }
 
+            if ($link->hasAttribute('node_remote_id')) {
+                $remote_id = $link->getAttribute('node_remote_id');
+                try {
+                    $location = $this->apiRepository->getLocationService()->loadLocationByRemoteId($remote_id);
+                    $link->setAttribute('node_id', $location->id);
+                } catch (NotFoundException $e) {
+                    // The link has to point to somewhere in order to be valid... Pointing to current page
+                    $link->setAttribute('href', '#');
+                    $this->logger->warning("Unable to find node with remote_id=$remote_id (so rewriting to href=\"#\"), when converting link where contentobject_attribute.id=$contentFieldId.");
+                }
+                continue;
+            }
             // The link has to point to somewhere in order to be valid... Pointing to current page
             $link->setAttribute('href', '#');
             $this->logger->warning("Unknown linktype detected when converting link where contentobject_attribute.id=$contentFieldId.");

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -39,16 +39,14 @@ class RichText implements Converter
     private $apiRepository;
 
     /**
+     * @var Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @var []
      */
     private $styleSheets;
-
-    /**
-     * Holds the id of the current contentField being converted.
-     *
-     * @var null|int
-     */
-    private $currentContentFieldId;
 
     /**
      * RichText constructor.
@@ -337,13 +335,14 @@ class RichText implements Converter
     /**
      * Check if $inputDocument has any embed|embed-inline tags without node_id or object_id.
      * @param DOMDocument $inputDocument
+     * @param $contentFieldId
      */
-    protected function checkEmptyEmbedTags(DOMDocument $inputDocument)
+    protected function checkEmptyEmbedTags(DOMDocument $inputDocument, $contentFieldId)
     {
         $xpath = new DOMXPath($inputDocument);
         $nodes = $xpath->query('//embed[not(@node_id|@object_id)] | //embed-inline[not(@node_id|@object_id)]');
         if ($nodes->length > 0) {
-            $this->logger->warning('Warning: ezxmltext for contentobject_attribute.id=' . $this->currentContentFieldId . 'contains embed or embed-inline tag(s) without node_id or object_id');
+            $this->logger->warning('Warning: ezxmltext for contentobject_attribute.id=' . $contentFieldId . 'contains embed or embed-inline tag(s) without node_id or object_id');
         }
     }
 
@@ -392,11 +391,12 @@ class RichText implements Converter
      * @param bool $checkIdValues
      * @param null|int $contentFieldId
      * @return string
+     * @throws \Exception
      */
     public function convert(DOMDocument $inputDocument, $checkDuplicateIds = false, $checkIdValues = false, $contentFieldId = null)
     {
         $this->removeComments($inputDocument);
-        $this->checkEmptyEmbedTags($inputDocument);
+        $this->checkEmptyEmbedTags($inputDocument, $contentFieldId);
         $this->checkLinkTags($inputDocument, $contentFieldId);
 
         try {

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -270,11 +270,6 @@
           <xsl:value-of select="concat( '', @href )"/>
         </xsl:attribute>
       </xsl:when>
-      <xsl:otherwise>
-        <xsl:message terminate="yes">
-          Unhandled link type
-        </xsl:message>
-      </xsl:otherwise>
     </xsl:choose>
     <xsl:attribute name="xlink:show">
       <xsl:choose>

--- a/tests/lib/FieldType/Converter/RichTextTest.php
+++ b/tests/lib/FieldType/Converter/RichTextTest.php
@@ -116,6 +116,24 @@ class RichTextTest extends TestCase
         }
     }
 
+    public function callbackLoadLocationByRemoteId($arg)
+    {
+        // We have to use callback because returnValueMap() is useless if one argument value is supposed
+        // to trow exception.
+        if ($arg === 'my_invalid_remote_id') {
+            throw new NotFoundException('foobar_message', 'foobar_identifier');
+        }
+        if ($arg === 'my_remote_id') {
+            $locationRemoteIdStub = $this->createMock(Location::class);
+            $locationRemoteIdStub
+                ->method('__get')
+                ->with($this->equalTo('id'))
+                ->willReturn(4242);
+
+            return $locationRemoteIdStub;
+        }
+    }
+
     private function createApiRepositoryStub()
     {
         $apiRepositoryStub = $this->createMock(Repository::class);
@@ -146,6 +164,8 @@ class RichTextTest extends TestCase
 
         $locationServiceStub->method('loadLocation')->willReturn($locationStub);
         $locationStub->method('getContentInfo')->willReturn($contentInfoImageStub);
+        $locationServiceStub->method('loadLocationByRemoteId')
+            ->will($this->returnCallBack([$this, 'callbackLoadLocationByRemoteId']));
 
         return $apiRepositoryStub;
     }

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/042-link_object_remote_id.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/042-link_object_remote_id.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>foobartext
+        <link object_remote_id="my_remote_id">link</link>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/043-link_object_remote_id_invalid.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/043-link_object_remote_id_invalid.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>foobartext
+        <link object_remote_id="my_invalid_remote_id">link</link>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/044-link_unhandled_link_type.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/044-link_unhandled_link_type.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>foobartext
+        <link not_supported="foobar">link</link>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/045-link_node_remote_id.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/045-link_node_remote_id.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>foobartext
+        <link node_remote_id="my_remote_id">link</link>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/046-link_node_remote_id_invalid.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/046-link_node_remote_id_invalid.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>foobartext
+        <link node_remote_id="my_invalid_remote_id">link</link>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/043-link_object_remote_id_invalid.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/043-link_object_remote_id_invalid.log
@@ -1,0 +1,1 @@
+warning:Unable to find content object with remote_id=my_invalid_remote_id (so rewriting to href="#"), when converting link where contentobject_attribute.id=.

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/044-link_unhandled_link_type.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/044-link_unhandled_link_type.log
@@ -1,0 +1,1 @@
+warning:Unknown linktype detected when converting link where contentobject_attribute.id=.

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/046-link_node_remote_id_invalid.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/046-link_node_remote_id_invalid.log
@@ -1,0 +1,1 @@
+warning:Unable to find node with remote_id=my_invalid_remote_id (so rewriting to href="#"), when converting link where contentobject_attribute.id=.

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/042-link_object_remote_id.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/042-link_object_remote_id.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+  <para>foobartext
+        <link xlink:href="ezcontent://42" xlink:show="none">link</link>
+    </para>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/043-link_object_remote_id_invalid.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/043-link_object_remote_id_invalid.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>foobartext
+        <link xlink:href="#" xlink:show="none">link</link>
+    </para>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/044-link_unhandled_link_type.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/044-link_unhandled_link_type.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>foobartext
+        <link xlink:href="#" xlink:show="none">link</link>
+    </para>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/045-link_node_remote_id.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/045-link_node_remote_id.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>foobartext
+        <link xlink:href="ezlocation://4242" xlink:show="none">link</link>
+    </para>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/046-link_node_remote_id_invalid.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/046-link_node_remote_id_invalid.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>foobartext
+        <link xlink:href="#" xlink:show="none">link</link>
+    </para>
+</section>


### PR DESCRIPTION
Fixes [EZP-29339](https://jira.ez.no/browse/EZP-29339)
Adds support for links like


```
<?xml version="1.0" encoding="utf-8"?>
<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
    <paragraph>foobartext
        <link object_remote_id="my_remote_id">link</link>
    </paragraph>
</section>
```