### PR TITLE
EZP-29349: ezxmltext -> ricktext conversion : exotic align values fail

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -116,9 +116,9 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@align">
-        <xsl:attribute name="ezxhtml:textalign">
-          <xsl:value-of select="translate(@align, $uppercase, $lowercase)"/>
-        </xsl:attribute>
+        <xsl:call-template name="textalign">
+          <xsl:with-param name="align" select="@align"/>
+        </xsl:call-template>
       </xsl:if>
       <xsl:variable name="lines" select="line"/>
       <xsl:choose>
@@ -322,9 +322,9 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@align">
-        <xsl:attribute name="ezxhtml:textalign">
-          <xsl:value-of select="translate(@align, $uppercase, $lowercase)"/>
-        </xsl:attribute>
+        <xsl:call-template name="textalign">
+          <xsl:with-param name="align" select="@align"/>
+        </xsl:call-template>
       </xsl:if>
       <xsl:apply-templates/>
     </xsl:element>
@@ -435,9 +435,9 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@align">
-        <xsl:attribute name="ezxhtml:textalign">
-          <xsl:value-of select="translate(@align, $uppercase, $lowercase)"/>
-        </xsl:attribute>
+        <xsl:call-template name="textalign">
+          <xsl:with-param name="align" select="@align"/>
+        </xsl:call-template>
       </xsl:if>
       <xsl:if test="@xhtml:width">
         <xsl:attribute name="ezxhtml:width">
@@ -481,9 +481,9 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@align">
-        <xsl:attribute name="ezxhtml:textalign">
-          <xsl:value-of select="translate(@align, $uppercase, $lowercase)"/>
-        </xsl:attribute>
+        <xsl:call-template name="textalign">
+          <xsl:with-param name="align" select="@align"/>
+        </xsl:call-template>
       </xsl:if>
       <xsl:if test="@xhtml:width">
         <xsl:attribute name="ezxhtml:width">
@@ -648,6 +648,46 @@
       </xsl:attribute>
       <xsl:value-of select="$attribute"/>
     </xsl:element>
+  </xsl:template>
+
+  <xsl:template name="textalign">
+    <xsl:param name="align"/>
+    <xsl:choose>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = '-moz-center'">
+        <xsl:attribute name="ezxhtml:textalign">center</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = '-moz-left'">
+        <xsl:attribute name="ezxhtml:textalign">left</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = '-moz-right'">
+        <xsl:attribute name="ezxhtml:textalign">right</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = '-webkit-auto'">
+        <!-- -webkit-auto not supported, remove alignment so it is inherited by parent-->
+        <!-- Once we support it, we may convert it to 'start'-->
+        <!--<xsl:attribute name="ezxhtml:textalign">start</xsl:attribute>-->
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = '-webkit-center'">
+        <xsl:attribute name="ezxhtml:textalign">center</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = '-webkit-left'">
+        <xsl:attribute name="ezxhtml:textalign">left</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = '-webkit-right'">
+        <xsl:attribute name="ezxhtml:textalign">right</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'end'">
+        <!-- end not supported ATM, removing-->
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'start'">
+        <!-- start not supported ATM, removing-->
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:attribute name="ezxhtml:textalign">
+          <xsl:value-of select="translate($align, $uppercase, $lowercase)"/>
+        </xsl:attribute>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/010-align.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/010-align.xml
@@ -8,4 +8,13 @@
     <paragraph align="center">aligne center</paragraph>
     <paragraph align="right">align right</paragraph>
     <paragraph align="justify">align fullheader align fullheaderalign fullheaderalign fullheaderalign fullheaderalign fullheaderalign fullheader</paragraph>
+    <paragraph align="-webkiT-auto">align webkit-auto</paragraph>
+    <paragraph align="-webkiT-center">align webkit-center</paragraph>
+    <paragraph align="-webkiT-left">align webkit-left</paragraph>
+    <paragraph align="-webkiT-right">align webkit-right</paragraph>
+    <paragraph align="-moZ-center">align moz-center</paragraph>
+    <paragraph align="-moZ-left">align moz-left</paragraph>
+    <paragraph align="-moZ-right">align moz-right</paragraph>
+    <paragraph align="start">align start</paragraph>
+    <paragraph align="end">align end</paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/010-align.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/010-align.xml
@@ -9,4 +9,13 @@
     <para ezxhtml:textalign="center">aligne center</para>
     <para ezxhtml:textalign="right">align right</para>
     <para ezxhtml:textalign="justify">align fullheader align fullheaderalign fullheaderalign fullheaderalign fullheaderalign fullheaderalign fullheader</para>
+    <para>align webkit-auto</para>
+    <para ezxhtml:textalign="center">align webkit-center</para>
+    <para ezxhtml:textalign="left">align webkit-left</para>
+    <para ezxhtml:textalign="right">align webkit-right</para>
+    <para ezxhtml:textalign="center">align moz-center</para>
+    <para ezxhtml:textalign="left">align moz-left</para>
+    <para ezxhtml:textalign="right">align moz-right</para>
+    <para>align start</para>
+    <para>align end</para>
 </section>


### PR DESCRIPTION
Fixes [EZP-29349](https://jira.ez.no/browse/EZP-29349)

Values like -webkit-auto, and others needs to be handled as RichText is more strict and only supports left, right, center & justify.