### PR TITLE
Fix "setHidden" method being undefined in Symfony 2.8

### DIFF
--- a/bundle/Command/ConvertXmlTextToRichTextCommandSubProcess.php
+++ b/bundle/Command/ConvertXmlTextToRichTextCommandSubProcess.php
@@ -17,7 +17,6 @@ class ConvertXmlTextToRichTextCommandSubProcess extends ConvertXmlTextToRichText
         $this
             ->setName('ezxmltext:convert-to-richtext-sub-process')
             ->setDescription('internal command used by ezxmltext:convert-to-richtext')
-            ->setHidden(true)
             ->addOption(
                 'offset',
                 null,


### PR DESCRIPTION
"setHidden" from Command class is undefined in Symfony 2.8 (it appeared in Symfony 3.2). This causes errors when clearing cache with EzSystemsEzPlatformXmlTextFieldTypeBundle enabled on eZ Platform 1.13.