### PR TITLE
EZP-29480: ezxmltext -> richtext conversion : ezxmltext containing ez-temporary attribute

### DIFF
--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/081-header-with-embed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/081-header-with-embed.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <header>
+        <embed size="original" object_id="127162"/>header text
+    </header>
+
+    <header>
+        <embed size="original" object_id="127163"/>
+    </header>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/091-table-empty-row.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/091-table-empty-row.xml
@@ -5,7 +5,7 @@
         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
         xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
     <paragraph
-            xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">
+            xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
         <table class="list" width="90%" border="0" ez-colums="3">
             <tr/>
             <tr>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/146-paragraph-temporary-ez-temporary.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/146-paragraph-temporary-ez-temporary.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+<!--    <embed view="embed" size="blog_author" object_id="108146" ezlegacytmp-embed-link-node_id="143254"/>-->
+    <section>
+        <header>Some header</header>
+        <section>
+            <paragraph
+                    xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">
+<strong>)</strong>
+            </paragraph>
+        </section>
+    </section>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/150-literal.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/150-literal.xml
@@ -6,7 +6,7 @@
     <paragraph>foobar1.</paragraph>
     <section>
         <paragraph
-                xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/" ez-temporary="1">
+                xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
             <literal>foobar2.</literal>
         </paragraph>
     </section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/081-header-with-embed.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/081-header-with-embed.log
@@ -1,0 +1,1 @@
+warning:Found embed(s) inside header tag. Embed(s) where moved outside header where contentobject_attribute.id=

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/146-paragraph-temporary-ez-temporary.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/146-paragraph-temporary-ez-temporary.log
@@ -1,0 +1,1 @@
+warning:Found ez-temporary attribute in a ezxmltext paragraphs. Removing such attribute where contentobject_attribute.id=

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/081-header-with-embed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/081-header-with-embed.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <title ezxhtml:level="2">header text
+    </title>
+  <ezembed xlink:href="ezcontent://127162">
+    <ezconfig>
+      <ezvalue key="size">original</ezvalue>
+    </ezconfig>
+  </ezembed>
+  <title ezxhtml:level="2"/>
+  <ezembed xlink:href="ezcontent://127163">
+    <ezconfig>
+      <ezvalue key="size">original</ezvalue>
+    </ezconfig>
+  </ezembed>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/146-paragraph-temporary-ez-temporary.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/146-paragraph-temporary-ez-temporary.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <title ezxhtml:level="2">Some header</title>
+  <para>
+    <emphasis role="strong">)</emphasis>
+  </para>
+</section>


### PR DESCRIPTION
This one fixes [ezp-29480](https://jira.ez.no/browse/EZP-29480)

It also adds a test case for https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/56