### PR TITLE
EZP-29507: ezxmltext -> richtext conversion: width attribute in table|tr|th elements containing "px"

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -382,7 +382,10 @@
       </xsl:if>
       <xsl:if test="@width">
         <xsl:attribute name="width">
-          <xsl:value-of select="@width"/>
+          <!-- Implementation of whitelist..
+           The inner translate() removes any character we actually accept, what remains is all unwanted characters in @width.
+           Those characters (and only those) are then removed by the outer translate()-->
+          <xsl:value-of select="translate(@width, translate(@width, '0123456789%', ''), '')"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@custom:summary != ''">
@@ -441,7 +444,7 @@
       </xsl:if>
       <xsl:if test="@xhtml:width">
         <xsl:attribute name="ezxhtml:width">
-          <xsl:value-of select="@xhtml:width"/>
+          <xsl:value-of select="translate(@xhtml:width, translate(@xhtml:width, '0123456789%', ''), '')"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@custom:valign">
@@ -487,7 +490,7 @@
       </xsl:if>
       <xsl:if test="@xhtml:width">
         <xsl:attribute name="ezxhtml:width">
-          <xsl:value-of select="@xhtml:width"/>
+          <xsl:value-of select="translate(@xhtml:width, translate(@xhtml:width, '0123456789%', ''), '')"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@custom:valign">

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/092-table-width.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/092-table-width.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <section>
+        <paragraph
+                xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+            <table width="1px">
+                <tr>
+                    <th xhtml:width="2px">
+                        <paragraph>foobar</paragraph>
+                    </th>
+                </tr>
+                <tr>
+                    <td xhtml:width="3px">
+                        <paragraph>foobar</paragraph>
+                    </td>
+                </tr>
+            </table>
+        </paragraph>
+    </section>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/092-table-width.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/092-table-width.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+  <informaltable width="1">
+    <tbody>
+      <tr>
+        <th ezxhtml:width="2">
+          <para>foobar</para>
+        </th>
+      </tr>
+      <tr>
+        <td ezxhtml:width="3">
+          <para>foobar</para>
+        </td>
+      </tr>
+    </tbody>
+  </informaltable>
+</section>


### PR DESCRIPTION
This one fixes [EZP-29507](https://jira.ez.no/browse/EZP-29507)