### PR TITLE
EZP-29529: ezxmltext -> richtext conversion: <ezembed> do not support align='justify'

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -559,7 +559,14 @@
       </xsl:if>
       <xsl:if test="@align">
         <xsl:attribute name="ezxhtml:align">
-          <xsl:value-of select="translate(@align, $uppercase, $lowercase)"/>
+          <xsl:choose>
+            <xsl:when test="translate(@align, $uppercase, $lowercase) = 'justify'">
+              <xsl:value-of select="'center'"/>
+            </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="translate(@align, $uppercase, $lowercase)"/>
+          </xsl:otherwise>
+          </xsl:choose>
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@*[starts-with( name( . ), 'ezlegacytmp-embed-link-' )]">

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/011-align-embed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/011-align-embed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <embed view="embed" align="justify" object_id="123"/>
+    <embed view="embed" align="left" object_id="123"/>
+    <embed view="embed" align="center" object_id="123"/>
+    <embed view="embed" align="right" object_id="123"/>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/011-align-embed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/011-align-embed.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
+  <ezembed view="embed" ezxhtml:align="center" xlink:href="ezcontent://123"/>
+  <ezembed view="embed" ezxhtml:align="left" xlink:href="ezcontent://123"/>
+  <ezembed view="embed" ezxhtml:align="center" xlink:href="ezcontent://123"/>
+  <ezembed view="embed" ezxhtml:align="right" xlink:href="ezcontent://123"/>
+</section>


### PR DESCRIPTION
This one fixes [EZP-29529](https://jira.ez.no/browse/EZP-29529)