### PR TITLE
EZP-29027: Added support for conversion of ezxmltest tag <literal> 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.11@dev || ^7.0@dev",
+        "ezsystems/ezpublish-kernel": "^6.13.6@dev || ^7.2.5@dev",
         "ezsystems/repository-forms": "^1.9 || ^2.0"
     },
     "require-dev": {

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -514,25 +514,6 @@ class RichText implements Converter
      * @param DOMDocument $document
      * @param null|int $contentFieldId
      */
-    protected function writeWarningOnNonSupportedLiterals(DOMDocument $document, $contentFieldId)
-    {
-        $xpath = new DOMXPath($document);
-
-        $xpathExpression = '//literal';
-
-        $elements = $xpath->query($xpathExpression);
-
-        foreach ($elements as $element) {
-            if ($element->getAttribute('class') !== 'html') {
-                $this->log(LogLevel::ERROR, "Only literal tag with class=\"html\" supported at the moment. Tag with different class removed where contentobject_attribute.id=$contentFieldId");
-            }
-        }
-    }
-
-    /**
-     * @param DOMDocument $document
-     * @param null|int $contentFieldId
-     */
     protected function writeWarningOnNonSupportedCustomTags(DOMDocument $document, $contentFieldId)
     {
         $xpath = new DOMXPath($document);
@@ -562,6 +543,25 @@ class RichText implements Converter
     }
 
     /**
+     * CDATA's content cannot contain the sequence ']]>' as that will terminate the CDATA section.
+     * So, if the end sequence ']]>' appears in the string, we split the text into multiple CDATA sections.
+     *
+     * @param DOMDocument $document
+     */
+    protected function encodeLiteral(DOMDocument $document)
+    {
+        $xpath = new DOMXPath($document);
+
+        $xpathExpression = '//literal[not(@class="html")]';
+
+        $elements = $xpath->query($xpathExpression);
+
+        foreach ($elements as $element) {
+            $element->textContent = str_replace(']]>', ']]]]><![CDATA[>', $element->textContent);
+        }
+    }
+
+    /**
      * Before calling this function, make sure you are logged in as admin, or at least have access to all the objects
      * being embedded and linked to in the $inputDocument.
      *
@@ -581,7 +581,7 @@ class RichText implements Converter
         $this->fixLinksWithRemoteIds($inputDocument, $contentFieldId);
         $this->flattenLinksInLinks($inputDocument, $contentFieldId);
         $this->moveEmbedsInHeaders($inputDocument, $contentFieldId);
-        $this->writeWarningOnNonSupportedLiterals($inputDocument, $contentFieldId);
+        $this->encodeLiteral($inputDocument);
 
         try {
             $convertedDocument = $this->getConverter()->convert($inputDocument);

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -103,6 +103,18 @@
           </xsl:if>
         </xsl:element>
       </xsl:when>
+      <xsl:otherwise>
+        <xsl:element name="programlisting">
+          <xsl:if test="@class">
+            <xsl:attribute name="language">
+              <xsl:value-of select="@class"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
+          <xsl:value-of disable-output-escaping="yes" select="./text()"/>
+          <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
+        </xsl:element>
+      </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -106,8 +106,13 @@
       <xsl:otherwise>
         <xsl:element name="programlisting">
           <xsl:if test="@class">
-            <xsl:attribute name="language">
+            <xsl:attribute name="ezxhtml:class">
               <xsl:value-of select="@class"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:if test="@custom:language">
+            <xsl:attribute name="language">
+              <xsl:value-of select="@custom:language"/>
             </xsl:attribute>
           </xsl:if>
           <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/150-literal.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/150-literal.xml
@@ -3,7 +3,10 @@
         xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
         xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
-    <paragraph>next one</paragraph>
+    <paragraph
+            xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+        <literal>Literal with CNAME end sequence here : ]]&gt; and some more text here</literal>
+    </paragraph>
     <paragraph
             xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
         <literal>ordinary literal</literal>
@@ -20,16 +23,7 @@
             xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
         <literal class="php">function foobar()
 {
-    thisIsSomePHPCode();
-    return 0;
-}</literal>
-    </paragraph>
-    <paragraph>the php one with language attribute:</paragraph>
-    <paragraph
-            xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
-        <literal class="red" custom:language="php">function foobar()
-{
-    thisIsSomePHPCode();
+    thisIsSomePHPCode('string with special characters &amp; &lt; &gt; â');
     return 0;
 }</literal>
     </paragraph>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/150-literal.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/150-literal.xml
@@ -27,4 +27,13 @@
     return 0;
 }</literal>
     </paragraph>
+    <paragraph>the php one with language attribute:</paragraph>
+    <paragraph
+            xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+        <literal class="red" custom:language="php">function foobar()
+{
+    thisIsSomePHPCode();
+    return 0;
+}</literal>
+    </paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/151-literal-class-html.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/151-literal-class-html.xml
@@ -6,7 +6,7 @@
     <paragraph>some text with bold tag</paragraph>
     <paragraph
             xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
-        <literal class="html">This is some &lt;b&gt;bold&lt;/b&gt; text&lt;br/&gt;</literal>
+        <literal class="html">this is some &lt;b&gt;html&lt;/b&gt; text</literal>
     </paragraph>
     <paragraph>some text with utf8 characters</paragraph>
     <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
@@ -16,5 +16,10 @@
     <paragraph>some text with nbsp character entities</paragraph>
     <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
         <literal class="html">&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;indend using nbsp entities&lt;br/&gt;</literal>
+    </paragraph>
+    <paragraph>some text with CNAME end sequence</paragraph>
+    <paragraph
+            xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+        <literal class="html">Literal with CNAME end sequence here : ]]&gt; and some more text here</literal>
     </paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/150-literal.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/150-literal.log
@@ -1,4 +1,0 @@
-error:Only literal tag with class="html" supported at the moment. Tag with different class removed where contentobject_attribute.id=
-error:Only literal tag with class="html" supported at the moment. Tag with different class removed where contentobject_attribute.id=
-error:Only literal tag with class="html" supported at the moment. Tag with different class removed where contentobject_attribute.id=
-error:Only literal tag with class="html" supported at the moment. Tag with different class removed where contentobject_attribute.id=

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/150-literal.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/150-literal.xml
@@ -1,5 +1,14 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
-  <para>next one</para>
+  <programlisting><![CDATA[Literal with CNAME end sequence here : ]]]]><![CDATA[> and some more text here]]></programlisting>
+  <programlisting><![CDATA[ordinary literal]]></programlisting>
+  <programlisting><![CDATA[more
+            complicated
+             literal
+              tag]]></programlisting>
   <para>the php one:</para>
-  <para>the php one with language attribute:</para>
+  <programlisting ezxhtml:class="php"><![CDATA[function foobar()
+{
+    thisIsSomePHPCode('string with special characters & < > â');
+    return 0;
+}]]></programlisting>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/150-literal.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/150-literal.xml
@@ -11,4 +11,10 @@
     thisIsSomePHPCode('string with special characters & < > â');
     return 0;
 }]]></programlisting>
+  <para>the php one with language attribute:</para>
+  <programlisting language="php" ezxhtml:class="red">function foobar()
+{
+    thisIsSomePHPCode();
+    return 0;
+}</programlisting>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/151-literal-class-html.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/151-literal-class-html.xml
@@ -1,7 +1,7 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
   <para>some text with bold tag</para>
   <eztemplate name="rawhtml">
-    <ezcontent>This is some &lt;b&gt;bold&lt;/b&gt; text&lt;br/&gt;</ezcontent>
+    <ezcontent>this is some &lt;b&gt;html&lt;/b&gt; text</ezcontent>
   </eztemplate>
   <para>some text with utf8 characters</para>
   <eztemplate name="rawhtml">
@@ -11,5 +11,9 @@
   <para>some text with nbsp character entities</para>
   <eztemplate name="rawhtml">
     <ezcontent>&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;indend using nbsp entities&lt;br/&gt;</ezcontent>
+  </eztemplate>
+  <para>some text with CNAME end sequence</para>
+  <eztemplate name="rawhtml">
+    <ezcontent>Literal with CNAME end sequence here : ]]&gt; and some more text here</ezcontent>
   </eztemplate>
 </section>


### PR DESCRIPTION
This PR implements [EZP-29027](https://jira.ez.no/browse/EZP-29027)

Depends on https://github.com/ezsystems/ezpublish-kernel/pull/2430
(tests fails due to that)