### PR TITLE
EZP-29595: ezxmltext -> richtext conversion : <header> inside <paragraph>

### DIFF
--- a/lib/FieldType/XmlText/Converter/ExpandingToRichText.php
+++ b/lib/FieldType/XmlText/Converter/ExpandingToRichText.php
@@ -32,6 +32,7 @@ class ExpandingToRichText extends Expanding
         ),
         'table' => array(),
         'literal' => array(),
+        'header' => array(),
     );
 
     /**

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/149-paragraph-with-header.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/149-paragraph-with-header.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/">
+    <paragraph>foobar1
+        <header level="5">Welcome1</header></paragraph>
+    <paragraph><header level="5">Welcome2</header>
+        foobar2</paragraph>
+    <table>
+        <tr>
+            <td>
+                <paragraph>
+                    <header level="5">Welcome3</header>
+                </paragraph>
+            </td>
+        </tr>
+    </table>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/149-paragraph-with-header.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/149-paragraph-with-header.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+  <para>foobar1
+        </para>
+  <title ezxhtml:level="2">Welcome1</title>
+  <title ezxhtml:level="2">Welcome2</title>
+  <para>
+        foobar2</para>
+  <informaltable>
+    <tbody>
+      <tr>
+        <td>
+          <title ezxhtml:level="2">Welcome3</title>
+        </td>
+      </tr>
+    </tbody>
+  </informaltable>
+</section>


### PR DESCRIPTION
This one fixes [EZP-29595](https://jira.ez.no/browse/EZP-29595)

The implementation of this one is different compared to https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/72 because we already have generic functionality for dealing with this kind of stuff  on paragraphs.

The downside is that no warnings or notices are logged on such occurrences though