### PR TITLE
Fixed RichTextTest so that tests fails if unexpected logs messages are created

### DIFF
--- a/tests/lib/FieldType/Converter/MethodCallCountConstraint.php
+++ b/tests/lib/FieldType/Converter/MethodCallCountConstraint.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the eZ Platform XmlText Field Type package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Converter;
+
+use PHPUnit_Framework_MockObject_Invocation;
+use PHPUnit_Framework_MockObject_Matcher_InvokedRecorder;
+use PHPUnit_Framework_ExpectationFailedException;
+
+/**
+ * Class MethodCallCountConstraint.
+ *
+ * When generating mocks in PHPUnit, you cannot validate that the mock methods are called the correct
+ * number of times.
+ *
+ * However, with this constrain you may.
+ * To ensure foobarMethod() is not called more than twice:
+ * $mock->expects(new MethodCallCountConstraint(2))->method('foobarMethod);
+ *
+ * Based on workaround proposed on https://github.com/sebastianbergmann/phpunit-mock-objects/issues/65
+ */
+class MethodCallCountConstraint extends PHPUnit_Framework_MockObject_Matcher_InvokedRecorder
+{
+    /**
+     * @var int
+     */
+    protected $expectedCount;
+
+    /**
+     * @param int $expectedCount
+     */
+    public function __construct($expectedCount)
+    {
+        $this->expectedCount = $expectedCount;
+    }
+
+    /**
+     * @param  PHPUnit_Framework_MockObject_Invocation $invocation
+     * @return mixed|void
+     * @throws PHPUnit_Framework_ExpectationFailedException
+     */
+    public function invoked(PHPUnit_Framework_MockObject_Invocation $invocation)
+    {
+        parent::invoked($invocation);
+
+        $count = $this->getInvocationCount();
+
+        if ($count > $this->expectedCount) {
+            $message = 'Call to ' . $invocation->toString() . ' unexpected';
+
+            throw new PHPUnit_Framework_ExpectationFailedException($message);
+        }
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'MethodCallCountConstraint';
+    }
+
+    /**
+     * Verifies that the current expectation is valid. If everything is OK the
+     * code should just return, if not it must throw an exception.
+     *
+     * @throws PHPUnit_Framework_ExpectationFailedException
+     */
+    public function verify()
+    {
+        $count = $this->getInvocationCount();
+        if ($count != $this->expectedCount) {
+            throw new PHPUnit_Framework_ExpectationFailedException(
+                sprintf(
+                    'Methods of class was expected to be called %d times, ' .
+                    'actually called %d times.',
+
+                    $this->expectedCount,
+                    $count
+                )
+            );
+        }
+    }
+}

--- a/tests/lib/FieldType/Converter/RichTextTest.php
+++ b/tests/lib/FieldType/Converter/RichTextTest.php
@@ -23,6 +23,11 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 class RichTextTest extends TestCase
 {
     /**
+     * @var \EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Converter\MethodCallCountConstraint
+     */
+    protected $methodCallCountConstraint = null;
+
+    /**
      * @param string $xml
      * @param bool $isPath
      *
@@ -173,6 +178,7 @@ class RichTextTest extends TestCase
     private function createLoggerStub($logFilePath)
     {
         $loggerStub = $this->createMock(NullLogger::class);
+        $callLogCount = 0;
 
         if ($logFilePath !== null) {
             $log = file_get_contents($logFilePath);
@@ -199,8 +205,11 @@ class RichTextTest extends TestCase
                         ->method('log')
                         ->with($logLevel, $logMessage);
                 }
+                ++$callLogCount;
             }
         }
+        $this->methodCallCountConstraint = new MethodCallCountConstraint($callLogCount);
+        $loggerStub->expects($this->methodCallCountConstraint)->method('log');
 
         return $loggerStub;
     }
@@ -221,6 +230,7 @@ class RichTextTest extends TestCase
         $richText->setImageContentTypes([27]);
 
         $result = $richText->convert($inputDocument, true, true);
+        $this->methodCallCountConstraint->verify();
 
         if ($result === false && !file_exists($outputFilePath)) {
             return;

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/002-dupid-embed.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/002-dupid-embed.log
@@ -1,1 +1,2 @@
 warning:Duplicated id in original ezxmltext for contentobject_attribute.id=[unknown], automatically generated new id : myembed_id --> duplicated_id_myembed_id_idm*
+warning:Duplicated id in original ezxmltext for contentobject_attribute.id=[unknown], automatically generated new id : myembed_id --> duplicated_id_myembed_id_idm*

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/003-dupid-anchor.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/003-dupid-anchor.log
@@ -1,1 +1,2 @@
 warning:Duplicated id in original ezxmltext for contentobject_attribute.id=[unknown], automatically generated new id : anchor --> duplicated_id_anchor_idm*
+warning:Duplicated id in original ezxmltext for contentobject_attribute.id=[unknown], automatically generated new id : anchor --> duplicated_id_anchor_idm*

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/081-header-with-embed.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/081-header-with-embed.log
@@ -1,1 +1,2 @@
 notice:Found embed(s) inside header tag. Embed(s) where moved outside header where contentobject_attribute.id=
+notice:Found embed(s) inside header tag. Embed(s) where moved outside header where contentobject_attribute.id=

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/150-literal.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/150-literal.log
@@ -1,1 +1,4 @@
 error:Only literal tag with class="html" supported at the moment. Tag with different class removed where contentobject_attribute.id=
+error:Only literal tag with class="html" supported at the moment. Tag with different class removed where contentobject_attribute.id=
+error:Only literal tag with class="html" supported at the moment. Tag with different class removed where contentobject_attribute.id=
+error:Only literal tag with class="html" supported at the moment. Tag with different class removed where contentobject_attribute.id=


### PR DESCRIPTION
Testsystem would not yell if conversion would fail with unexpected schema validation error.

Ref. https://github.com/sebastianbergmann/phpunit-mock-objects/issues/65