### PR TITLE
EZP-29697: ezxmltext -> richtext conversion : Give user a report of custom tag usage

### DIFF
--- a/bundle/Command/ConvertXmlTextToRichTextCommand.php
+++ b/bundle/Command/ConvertXmlTextToRichTextCommand.php
@@ -81,15 +81,15 @@ class ConvertXmlTextToRichTextCommand extends ContainerAwareCommand
      */
     protected $kernelCacheDir;
 
-    public function __construct(Connection $dbal, RichTextConverter $converter, LoggerInterface $logger, $kernelCacheDir)
+    public function __construct(Connection $dbal, RichTextConverter $converter, $kernelCacheDir, LoggerInterface $logger)
     {
         parent::__construct();
 
         $this->dbal = $dbal;
-        $this->logger = $logger;
         $this->converter = $converter;
-        $this->exportDir = '';
         $this->kernelCacheDir = $kernelCacheDir;
+        $this->logger = $logger;
+        $this->exportDir = '';
     }
 
     protected function configure()
@@ -280,12 +280,17 @@ EOT
     {
         $customTagLog = $this->converter->getCustomTagLog();
         if (count($customTagLog[RichTextConverter::INLINE_CUSTOM_TAG]) > 0) {
-            file_put_contents($this->getCustomTagLogFileName(), RichTextConverter::INLINE_CUSTOM_TAG . ':' . implode(',',
-                    $customTagLog[RichTextConverter::INLINE_CUSTOM_TAG]) . "\n", FILE_APPEND);
+            file_put_contents(
+                $this->getCustomTagLogFileName(),
+                RichTextConverter::INLINE_CUSTOM_TAG . ':' . implode(',', $customTagLog[RichTextConverter::INLINE_CUSTOM_TAG]) . PHP_EOL,
+                FILE_APPEND
+            );
         }
         if (count($customTagLog[RichTextConverter::BLOCK_CUSTOM_TAG]) > 0) {
-            file_put_contents($this->getCustomTagLogFileName(), RichTextConverter::BLOCK_CUSTOM_TAG . ':' . implode(',',
-                    $customTagLog[RichTextConverter::BLOCK_CUSTOM_TAG]) . "\n", FILE_APPEND);
+            file_put_contents($this->getCustomTagLogFileName(),
+                RichTextConverter::BLOCK_CUSTOM_TAG . ':' . implode(',', $customTagLog[RichTextConverter::BLOCK_CUSTOM_TAG]) . PHP_EOL,
+                FILE_APPEND
+            );
         }
     }
 
@@ -300,7 +305,7 @@ EOT
     protected function reportCustomTags(InputInterface $input, OutputInterface $output)
     {
         $customTagsFile = file_get_contents($this->getCustomTagLogFileName());
-        $separator = "\n";
+        $separator = PHP_EOL;
         $line = strtok($customTagsFile, $separator);
         $inlines = [];
         $blocks = [];

--- a/bundle/Command/ConvertXmlTextToRichTextCommand.php
+++ b/bundle/Command/ConvertXmlTextToRichTextCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use eZ\Publish\Core\FieldType\XmlText\Value;
 use eZ\Publish\Core\FieldType\XmlText\Converter\RichText as RichTextConverter;
 use Doctrine\DBAL\Connection;
@@ -75,7 +76,12 @@ class ConvertXmlTextToRichTextCommand extends ContainerAwareCommand
      */
     protected $userLogin;
 
-    public function __construct(Connection $dbal, RichTextConverter $converter, LoggerInterface $logger)
+    /**
+     * @var string
+     */
+    protected $kernelCacheDir;
+
+    public function __construct(Connection $dbal, RichTextConverter $converter, LoggerInterface $logger, $kernelCacheDir)
     {
         parent::__construct();
 
@@ -83,6 +89,7 @@ class ConvertXmlTextToRichTextCommand extends ContainerAwareCommand
         $this->logger = $logger;
         $this->converter = $converter;
         $this->exportDir = '';
+        $this->kernelCacheDir = $kernelCacheDir;
     }
 
     protected function configure()
@@ -170,6 +177,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->baseExecute($input, $output, $dryRun);
+        $this->createCustomTagLog();
         if ($dryRun) {
             $output->writeln('Running in dry-run mode. No changes will actually be written to database');
             if ($this->exportDir !== '') {
@@ -199,6 +207,8 @@ EOT
         }
 
         $this->processFields($dryRun, !$input->getOption('disable-duplicate-id-check'), !$input->getOption('disable-id-value-check'), $output);
+        $this->reportCustomTags($input, $output);
+        $this->removeCustomTagLog();
     }
 
     protected function baseExecute(InputInterface $input, OutputInterface $output, &$dryRun)
@@ -253,6 +263,79 @@ EOT
             throw new RuntimeException('Unable to lookup all content type identifiers, not found: ' . implode(',', array_diff($this->imageContentTypeIdentifiers, array_keys($imageContentTypeIds))));
         }
         $this->converter->setImageContentTypes($imageContentTypeIds);
+    }
+
+    protected function getCustomTagLogFileName()
+    {
+        return $this->kernelCacheDir . DIRECTORY_SEPARATOR . 'customtags.log';
+    }
+
+    protected function createCustomTagLog()
+    {
+        $this->removeCustomTagLog();
+        touch($this->getCustomTagLogFileName());
+    }
+
+    protected function writeCustomTagLog()
+    {
+        $customTagLog = $this->converter->getCustomTagLog();
+        if (count($customTagLog[RichTextConverter::INLINE_CUSTOM_TAG]) > 0) {
+            file_put_contents($this->getCustomTagLogFileName(), RichTextConverter::INLINE_CUSTOM_TAG . ':' . implode(',',
+                    $customTagLog[RichTextConverter::INLINE_CUSTOM_TAG]) . "\n", FILE_APPEND);
+        }
+        if (count($customTagLog[RichTextConverter::BLOCK_CUSTOM_TAG]) > 0) {
+            file_put_contents($this->getCustomTagLogFileName(), RichTextConverter::BLOCK_CUSTOM_TAG . ':' . implode(',',
+                    $customTagLog[RichTextConverter::BLOCK_CUSTOM_TAG]) . "\n", FILE_APPEND);
+        }
+    }
+
+    protected function removeCustomTagLog()
+    {
+        $filename = $this->getCustomTagLogFileName();
+        if (file_exists($filename)) {
+            unlink($filename);
+        }
+    }
+
+    protected function reportCustomTags(InputInterface $input, OutputInterface $output)
+    {
+        $customTagsFile = file_get_contents($this->getCustomTagLogFileName());
+        $separator = "\n";
+        $line = strtok($customTagsFile, $separator);
+        $inlines = [];
+        $blocks = [];
+
+        while ($line !== false) {
+            // line will have format 'inline:customtag1,customtag2'
+            $lineSplit = explode(':', $line);
+            switch ($lineSplit[0]) {
+                case RichTextConverter::INLINE_CUSTOM_TAG:
+                    $inlines = array_merge($inlines, explode(',', $lineSplit[1]));
+                    break;
+                case RichTextConverter::BLOCK_CUSTOM_TAG:
+                    $blocks = array_merge($blocks, explode(',', $lineSplit[1]));
+                    break;
+            }
+
+            $line = strtok($separator);
+        }
+        $inlines = array_unique($inlines, SORT_LOCALE_STRING);
+        $blocks = array_unique($blocks, SORT_LOCALE_STRING);
+
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Custom tags overview');
+        $io->text('Below are the list of custom tags found during conversion of ezxmltext fields');
+        $io->section('Inline custom tags');
+        $io->listing($inlines);
+        if (count($inlines) === 0) {
+            $io->text('No inline custom tags converted');
+        }
+
+        $io->section('Block custom tags');
+        $io->listing($blocks);
+        if (count($blocks) === 0) {
+            $io->text('No block custom tags converted');
+        }
     }
 
     protected function getContentTypeIds($contentTypeIdentifiers)
@@ -652,6 +735,7 @@ EOT
                 ]
             );
         }
+        $this->writeCustomTagLog();
     }
 
     protected function processFields($dryRun, $checkDuplicateIds, $checkIdValues, OutputInterface $output)

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -12,8 +12,8 @@ services:
         arguments:
             - "@ezpublish.persistence.connection"
             - "@ezxmltext.richtext_converter"
-            - "@?logger"
             - "%kernel.cache_dir%"
+            - "@?logger"
         tags:
             -  { name: console.command }
 

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -13,6 +13,7 @@ services:
             - "@ezpublish.persistence.connection"
             - "@ezxmltext.richtext_converter"
             - "@?logger"
+            - "%kernel.cache_dir%"
         tags:
             -  { name: console.command }
 

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -24,7 +24,7 @@ use Symfony\Component\Debug\Exception\ContextErrorException;
 
 class RichText implements Converter
 {
-    const INLINE_CUSTOM_TAG = 'line';
+    const INLINE_CUSTOM_TAG = 'inline';
     const BLOCK_CUSTOM_TAG = 'block';
     /**
      * @var \eZ\Publish\Core\FieldType\RichText\Converter

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -24,6 +24,8 @@ use Symfony\Component\Debug\Exception\ContextErrorException;
 
 class RichText implements Converter
 {
+    const INLINE_CUSTOM_TAG = 'line';
+    const BLOCK_CUSTOM_TAG = 'block';
     /**
      * @var \eZ\Publish\Core\FieldType\RichText\Converter
      */
@@ -56,6 +58,11 @@ class RichText implements Converter
     private $errors;
 
     /**
+     * @var []
+     */
+    private $customTagsLog;
+
+    /**
      * RichText constructor.
      * @param null $apiRepository
      * @param LoggerInterface|null $logger
@@ -69,6 +76,21 @@ class RichText implements Converter
         $this->styleSheets = null;
         $this->validator = null;
         $this->converter = null;
+        $this->customTagsLog = [self::INLINE_CUSTOM_TAG => [], self::BLOCK_CUSTOM_TAG => []];
+    }
+
+    /**
+     * @param string $customTagType
+     * @param string $customTagName
+     */
+    protected function logCustomTag($customTagType, $customTagName)
+    {
+        $this->customTagsLog[$customTagType][] = $customTagName;
+    }
+
+    public function getCustomTagLog()
+    {
+        return $this->customTagsLog;
     }
 
     /**
@@ -553,10 +575,12 @@ class RichText implements Converter
 
             if (!$blockCustomTag) {
                 $this->log(LogLevel::WARNING, "Inline custom tag '$customTagName' not supported by editor at the moment. You'll not be able to edit content correctly in editor where contentobject_attribute.id=$contentFieldId");
-            }
-
-            if ($parent->localName === 'section') {
+                $this->logCustomTag(self::INLINE_CUSTOM_TAG, $customTagName);
+            } elseif ($parent->localName === 'section') {
                 $this->log(LogLevel::WARNING, "Custom tag '$customTagName' converted to block custom tag. It might have been inline custom tag in legacy DB where contentobject_attribute.id=$contentFieldId");
+                $this->logCustomTag(self::BLOCK_CUSTOM_TAG, $customTagName);
+            } else {
+                $this->logCustomTag(self::BLOCK_CUSTOM_TAG, $customTagName);
             }
         }
     }


### PR DESCRIPTION
This one implements [EZP-29697](https://jira.ez.no/browse/EZP-29697)

This PR adds a report of custom tags being processed during conversion

Example:

```
Custom tags overview
====================

 Below are the list of custom tags found during conversion of ezxmltext fields

Inline custom tags
------------------

 * custom3
 * custom4

Block custom tags
-----------------

 * factbox
 * custom1
 * custom2
```