### PR TITLE
Fix EZEE-1871 Solr cannot index string field which is too large.

### DIFF
--- a/lib/FieldType/XmlText/SearchField.php
+++ b/lib/FieldType/XmlText/SearchField.php
@@ -39,7 +39,7 @@ class SearchField implements Indexable
             new Search\Field(
                 'value',
                 $this->extractShortText($document),
-                new Search\FieldType\StringField()
+                new Search\FieldType\TextField()
             ),
             new Search\Field(
                 'fulltext',

--- a/lib/FieldType/XmlText/SearchField.php
+++ b/lib/FieldType/XmlText/SearchField.php
@@ -106,7 +106,7 @@ class SearchField implements Indexable
     public function getIndexDefinition()
     {
         return array(
-            'value' => new Search\FieldType\StringField(),
+            'value' => new Search\FieldType\TextField(),
         );
     }
 


### PR DESCRIPTION
Trying to index XmlTextBlock text as StringField() causes Solr Exception in some cases due to legth overflow.