### PR TITLE
EZP-29331: Custom Tags added in Legacy Bridge gets rendered inside paragraph in the new stack

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -259,4 +259,15 @@
         </xsl:copy>
     </xsl:template>
 
+    <xsl:template match="paragraph[not(text())][custom][count(custom)=count(*)]">
+        <xsl:apply-templates select="custom"/>
+    </xsl:template>
+
+    <xsl:template match="@custom|node()">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates select="@custom|node()" />
+        </xsl:copy>
+    </xsl:template>
+
 </xsl:stylesheet>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/input/112-removeCustomTagsWrappingParagraph.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/input/112-removeCustomTagsWrappingParagraph.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>Lorem ipsum.</paragraph>
+    <paragraph>
+        <custom name="test1">One</custom>
+        <custom name="test2" attr="test2a">Two</custom>
+        <custom name="test3"/>
+    </paragraph>
+    <paragraph>Lorem ipsum</paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/html5/output/112-removeCustomTagsWrappingParagraph.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/html5/output/112-removeCustomTagsWrappingParagraph.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
+    <p>Lorem ipsum.</p>
+    <custom name="test1">One</custom>
+    <custom name="test2" attr="test2a">Two</custom>
+    <custom name="test3"/>
+    <p>Lorem ipsum</p>
+</section>


### PR DESCRIPTION
JIRA issue: [EZP-29331](https://jira.ez.no/browse/EZP-29331)

When rendering XML block Field inside new stack consecutive Custom Tags will be rendered inside unwanted additional `<p>` tag. This PR fixes this issue by searching for a paragraph with no text and only `<custom>` tags inside and deletes it, putting its children in its place.

**Todo:**
- [x] Tests