### PR TITLE
Injected RichText Validator from DIC into RichText Converter

### DIFF
--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -39,5 +39,6 @@ services:
     ezxmltext.richtext_converter:
         class: eZ\Publish\Core\FieldType\XmlText\Converter\RichText
         arguments:
+            - "@ezrichtext.validator.docbook"
             - "@ezpublish.api.repository"
             - "@?logger"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -39,6 +39,6 @@ services:
     ezxmltext.richtext_converter:
         class: eZ\Publish\Core\FieldType\XmlText\Converter\RichText
         arguments:
-            - "@ezrichtext.validator.docbook"
             - "@ezpublish.api.repository"
             - "@?logger"
+            - "@ezpublish.fieldType.ezrichtext.validator.docbook"

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -37,16 +37,16 @@ class RichText implements Converter
      */
     private $imageContentTypes;
     /**
-     * @var eZ\Publish\Core\FieldType\RichText\Validator
+     * @var \eZ\Publish\Core\FieldType\RichText\Validator
      */
     private $validator;
     /**
-     * @var eZ\Publish\API\Repository\Repository
+     * @var \eZ\Publish\API\Repository\Repository
      */
     private $apiRepository;
 
     /**
-     * @var Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     private $logger;
 

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -21,7 +21,7 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use Psr\Log\NullLogger;
 use Psr\Log\LogLevel;
 use Symfony\Component\Debug\Exception\ContextErrorException;
-use eZ\Publish\Core\SignalSlot\Repository;
+use eZ\Publish\API\Repository\Repository;
 
 class RichText implements Converter
 {
@@ -37,10 +37,12 @@ class RichText implements Converter
      */
     private $imageContentTypes;
     /**
-     * @var Validator
+     * @var eZ\Publish\Core\FieldType\RichText\Validator
      */
     private $validator;
-
+    /**
+     * @var eZ\Publish\API\Repository\Repository
+     */
     private $apiRepository;
 
     /**

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -16,11 +16,12 @@ use DOMNode;
 use Psr\Log\LoggerInterface;
 use eZ\Publish\Core\FieldType\RichText\Converter\Aggregate;
 use eZ\Publish\Core\FieldType\RichText\Converter\Xslt;
-use EzSystems\EzPlatformRichText\eZ\RichText\ValidatorInterface;
+use eZ\Publish\Core\FieldType\RichText\Validator;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use Psr\Log\NullLogger;
 use Psr\Log\LogLevel;
 use Symfony\Component\Debug\Exception\ContextErrorException;
+use eZ\Publish\Core\SignalSlot\Repository;
 
 class RichText implements Converter
 {
@@ -36,7 +37,7 @@ class RichText implements Converter
      */
     private $imageContentTypes;
     /**
-     * @var ValidatorInterface
+     * @var Validator
      */
     private $validator;
 
@@ -64,14 +65,14 @@ class RichText implements Converter
 
     /**
      * RichText constructor.
-     * @param null $validator
      * @param null $apiRepository
      * @param LoggerInterface|null $logger
+     * @param Validator $validator
      */
     public function __construct(
-        ValidatorInterface $validator = null,
-        $apiRepository = null,
-        LoggerInterface $logger = null
+        Repository $apiRepository = null,
+        LoggerInterface $logger = null,
+        Validator $validator = null
     ) {
         $this->validator = $validator;
 

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -65,7 +65,7 @@ class RichText implements Converter
 
     /**
      * RichText constructor.
-     * @param null $apiRepository
+     * @param Repository $apiRepository
      * @param LoggerInterface|null $logger
      * @param Validator $validator
      */

--- a/tests/lib/FieldType/Converter/EzxmlToDocbookTest.php
+++ b/tests/lib/FieldType/Converter/EzxmlToDocbookTest.php
@@ -75,6 +75,7 @@ class EzxmlToDocbookTest extends BaseTest
             $validator = new Validator($validatorSchemas);
             $converter = new RichText($apiRepositoryStub, null, $validator);
             $converter->setCustomStylesheets($customStylesheets);
+
             return $converter;
         }
 

--- a/tests/lib/FieldType/Converter/EzxmlToDocbookTest.php
+++ b/tests/lib/FieldType/Converter/EzxmlToDocbookTest.php
@@ -59,7 +59,7 @@ class EzxmlToDocbookTest extends BaseTest
     {
         $validatorSchemas = [
             './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng',
-            './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl'
+            './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl',
         ];
         $apiRepositoryStub = $this->createApiRepositoryStub();
 

--- a/tests/lib/FieldType/Converter/EzxmlToDocbookTest.php
+++ b/tests/lib/FieldType/Converter/EzxmlToDocbookTest.php
@@ -8,6 +8,7 @@
  */
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Converter;
 
+use eZ\Publish\Core\FieldType\RichText\Validator;
 use eZ\Publish\Core\FieldType\XmlText\Converter\RichText;
 use eZ\Publish\Core\SignalSlot\Repository;
 use eZ\Publish\API\Repository\ContentService;
@@ -56,25 +57,30 @@ class EzxmlToDocbookTest extends BaseTest
      */
     protected function getConverter($inputFile)
     {
-        if (basename($inputFile) === '017-customYoutube.xml') {
-            $apiRepositoryStub = $this->createApiRepositoryStub();
-            $customStylesheets =
-                [
-                    [
-                        'path' => __DIR__ . '/Xslt/_fixtures/ezxml/custom_stylesheets/youtube_docbook.xsl',
-                        'priority' => 100,
-                    ],
-                ];
-            $customValidators = [__DIR__ . '/../../../../tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/custom_schemas/youtube.rng'];
-            $converter = new RichText($apiRepositoryStub);
-            $converter->setCustomStylesheets($customStylesheets);
-            $converter->setCustomValidators($customValidators);
+        $validatorSchemas = [
+            './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng',
+            './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl'
+        ];
+        $apiRepositoryStub = $this->createApiRepositoryStub();
 
+        if (basename($inputFile) === '017-customYoutube.xml') {
+            $customStylesheets = [
+                [
+                    'path' => __DIR__ . '/Xslt/_fixtures/ezxml/custom_stylesheets/youtube_docbook.xsl',
+                    'priority' => 100,
+                ],
+            ];
+            $validatorSchemas[] = __DIR__ . '/../../../../tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/custom_schemas/youtube.rng';
+
+            $validator = new Validator($validatorSchemas);
+            $converter = new RichText($apiRepositoryStub, null, $validator);
+            $converter->setCustomStylesheets($customStylesheets);
             return $converter;
         }
+
         if ($this->converter === null) {
-            $apiRepositoryStub = $this->createApiRepositoryStub();
-            $this->converter = new RichText($apiRepositoryStub);
+            $validator = new Validator($validatorSchemas);
+            $this->converter = new RichText($apiRepositoryStub, null, $validator);
         }
 
         return $this->converter;

--- a/tests/lib/FieldType/Converter/RichTextTest.php
+++ b/tests/lib/FieldType/Converter/RichTextTest.php
@@ -19,6 +19,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use Psr\Log\NullLogger;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\FieldType\RichText\Validator;
 
 class RichTextTest extends TestCase
 {
@@ -224,9 +225,10 @@ class RichTextTest extends TestCase
     {
         $apiRepositoryStub = $this->createApiRepositoryStub();
         $loggerStub = $this->createLoggerStub($logFilePath);
+        $validator = $this->getValidator();
 
         $inputDocument = $this->createDocument($inputFilePath);
-        $richText = new RichText($apiRepositoryStub, $loggerStub);
+        $richText = new RichText($apiRepositoryStub, $loggerStub, $validator);
         $richText->setImageContentTypes([27]);
 
         $result = $richText->convert($inputDocument, true, true);
@@ -252,6 +254,15 @@ class RichTextTest extends TestCase
         );
     }
 
+    public function getValidator() {
+        return new Validator(
+            array(
+                './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng',
+                './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl'
+            )
+        );
+    }
+
     /**
      * @param string $inputFilePath
      * @param string $outputFilePath
@@ -261,9 +272,10 @@ class RichTextTest extends TestCase
     public function testTagEmbeddedImages($inputFilePath, $outputFilePath)
     {
         $apiRepositoryStub = $this->createApiRepositoryStub();
+        $validator = $this->getValidator();
 
         $inputDocument = $this->createDocument($inputFilePath);
-        $richText = new RichText($apiRepositoryStub);
+        $richText = new RichText($apiRepositoryStub, null, $validator);
         $richText->setImageContentTypes(array(27));
 
         $richText->tagEmbeddedImages($inputDocument, null);

--- a/tests/lib/FieldType/Converter/RichTextTest.php
+++ b/tests/lib/FieldType/Converter/RichTextTest.php
@@ -254,11 +254,12 @@ class RichTextTest extends TestCase
         );
     }
 
-    public function getValidator() {
+    public function getValidator()
+    {
         return new Validator(
             array(
                 './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng',
-                './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl'
+                './vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl',
             )
         );
     }


### PR DESCRIPTION
// maintainer update:
Injecting proper DIC service will result in implicit swapping of this Validator when RichText bundle is enabled (it replaced `eZ\Publish\Core\FieldType\RichText`).

_Note: if we intend to somehow support this bundle still with 3.0, then we will have to bump requirements and inject proper service from the RichText bundle_