### PR TITLE
EZP-30507: Strict possible values for align attribute

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -720,10 +720,24 @@
       <xsl:when test="translate($align, $uppercase, $lowercase) = 'start'">
         <!-- start not supported ATM, removing-->
       </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'center'">
+        <xsl:attribute name="ezxhtml:textalign">center</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'left'">
+        <xsl:attribute name="ezxhtml:textalign">left</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'right'">
+        <xsl:attribute name="ezxhtml:textalign">right</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'justify'">
+        <xsl:attribute name="ezxhtml:textalign">justify</xsl:attribute>
+      </xsl:when>
       <xsl:otherwise>
+        <!-- we can not use custom values here, as it will break richtext shema
         <xsl:attribute name="ezxhtml:textalign">
           <xsl:value-of select="translate($align, $uppercase, $lowercase)"/>
         </xsl:attribute>
+        -->
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -732,13 +732,6 @@
       <xsl:when test="translate($align, $uppercase, $lowercase) = 'justify'">
         <xsl:attribute name="ezxhtml:textalign">justify</xsl:attribute>
       </xsl:when>
-      <xsl:otherwise>
-        <!-- we can not use custom values here, as it will break richtext shema
-        <xsl:attribute name="ezxhtml:textalign">
-          <xsl:value-of select="translate($align, $uppercase, $lowercase)"/>
-        </xsl:attribute>
-        -->
-      </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
 

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -29,7 +29,7 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@custom:align">
-        <xsl:call-template name="customtagalign">
+        <xsl:call-template name="align">
           <xsl:with-param name="align" select="@custom:align"/>
         </xsl:call-template>
       </xsl:if>
@@ -61,7 +61,7 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@custom:align">
-        <xsl:call-template name="customtagalign">
+        <xsl:call-template name="align">
           <xsl:with-param name="align" select="@custom:align"/>
         </xsl:call-template>
       </xsl:if>
@@ -589,7 +589,7 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@align">
-        <xsl:call-template name="customtagalign">
+        <xsl:call-template name="align">
           <xsl:with-param name="align" select="@align"/>
         </xsl:call-template>
       </xsl:if>
@@ -728,7 +728,7 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template name="customtagalign">
+  <xsl:template name="align">
     <xsl:param name="align"/>
     <xsl:choose>
       <xsl:when test="translate($align, $uppercase, $lowercase) = 'center'">

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -29,9 +29,9 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@custom:align">
-        <xsl:attribute name="ezxhtml:align">
-          <xsl:value-of select="translate(@custom:align, $uppercase, $lowercase)"/>
-        </xsl:attribute>
+        <xsl:call-template name="customtagalign">
+          <xsl:with-param name="align" select="@custom:align"/>
+        </xsl:call-template>
       </xsl:if>
       <xsl:if test="./text()">
         <xsl:element name="ezcontent" namespace="http://docbook.org/ns/docbook">
@@ -61,9 +61,9 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@custom:align">
-        <xsl:attribute name="ezxhtml:align">
-          <xsl:value-of select="translate(@custom:align, $uppercase, $lowercase)"/>
-        </xsl:attribute>
+        <xsl:call-template name="customtagalign">
+          <xsl:with-param name="align" select="@custom:align"/>
+        </xsl:call-template>
       </xsl:if>
       <xsl:if test="./* | ./text()">
         <xsl:element name="ezcontent" namespace="http://docbook.org/ns/docbook">
@@ -589,16 +589,9 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@align">
-        <xsl:attribute name="ezxhtml:align">
-          <xsl:choose>
-            <xsl:when test="translate(@align, $uppercase, $lowercase) = 'justify'">
-              <xsl:value-of select="'center'"/>
-            </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="translate(@align, $uppercase, $lowercase)"/>
-          </xsl:otherwise>
-          </xsl:choose>
-        </xsl:attribute>
+        <xsl:call-template name="customtagalign">
+          <xsl:with-param name="align" select="@align"/>
+        </xsl:call-template>
       </xsl:if>
       <xsl:if test="@*[starts-with( name( . ), 'ezlegacytmp-embed-link-' )]">
         <xsl:element name="ezlink" namespace="http://docbook.org/ns/docbook">
@@ -731,6 +724,24 @@
       </xsl:when>
       <xsl:when test="translate($align, $uppercase, $lowercase) = 'justify'">
         <xsl:attribute name="ezxhtml:textalign">justify</xsl:attribute>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="customtagalign">
+    <xsl:param name="align"/>
+    <xsl:choose>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'center'">
+        <xsl:attribute name="ezxhtml:align">center</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'left'">
+        <xsl:attribute name="ezxhtml:align">left</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'right'">
+        <xsl:attribute name="ezxhtml:align">right</xsl:attribute>
+      </xsl:when>
+      <xsl:when test="translate($align, $uppercase, $lowercase) = 'justify'">
+        <xsl:attribute name="ezxhtml:align">justify</xsl:attribute>
       </xsl:when>
     </xsl:choose>
   </xsl:template>

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -741,7 +741,7 @@
         <xsl:attribute name="ezxhtml:align">right</xsl:attribute>
       </xsl:when>
       <xsl:when test="translate($align, $uppercase, $lowercase) = 'justify'">
-        <xsl:attribute name="ezxhtml:align">justify</xsl:attribute>
+        <xsl:attribute name="ezxhtml:align">center</xsl:attribute>
       </xsl:when>
     </xsl:choose>
   </xsl:template>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/002-para.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/002-para.xml
@@ -11,4 +11,5 @@
   <para ezxhtml:textalign="right">This is a right aligned paragraph.</para>
   <para ezxhtml:textalign="justify">This is a justified paragraph.</para>
   <para>this is a paragraph with unsupported align attribute.</para>
+  <para ezxhtml:textalign="left">this is a paragraph with translated valid align attribute.</para>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/002-para.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/002-para.xml
@@ -10,4 +10,5 @@
   <para ezxhtml:textalign="center">This is a centered paragraph.</para>
   <para ezxhtml:textalign="right">This is a right aligned paragraph.</para>
   <para ezxhtml:textalign="justify">This is a justified paragraph.</para>
+  <para>this is a paragraph with unsupported align attribute.</para>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/002-para.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/002-para.xml
@@ -10,6 +10,6 @@
   <para ezxhtml:textalign="center">This is a centered paragraph.</para>
   <para ezxhtml:textalign="right">This is a right aligned paragraph.</para>
   <para ezxhtml:textalign="justify">This is a justified paragraph.</para>
-  <para>this is a paragraph with unsupported align attribute.</para>
-  <para ezxhtml:textalign="left">this is a paragraph with translated valid align attribute.</para>
+  <para>This is a paragraph with unsupported align attribute.</para>
+  <para ezxhtml:textalign="left">This is a paragraph with translated valid align attribute.</para>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/022-embed.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/022-embed.xml
@@ -12,4 +12,5 @@
     </ezconfig>
   </ezembed>
   <ezembed xlink:href="ezlocation://601" view="line" xml:id="embed-id-2" ezxhtml:class="embedClass2" ezxhtml:align="right"/>
+  <ezembed xlink:href="ezlocation://601" view="line" xml:id="embed-id-3" ezxhtml:class="embedClass2"/>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/024-template.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/024-template.xml
@@ -44,4 +44,5 @@
     <ezcontent>It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</ezcontent>
   </eztemplate>
   <eztemplate name="factoidbox" ezxhtml:class="templateClass4" ezxhtml:align="center"/>
+  <eztemplate name="factoidbox" ezxhtml:class="templateClass4"/>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/002-para.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/002-para.xml
@@ -10,4 +10,5 @@
   <paragraph align="center">This is a centered paragraph.</paragraph>
   <paragraph align="right">This is a right aligned paragraph.</paragraph>
   <paragraph align="justify">This is a justified paragraph.</paragraph>
+  <paragraph align="unsupported">This is a paragraph with unsupported align attribute.</paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/002-para.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/002-para.xml
@@ -11,4 +11,5 @@
   <paragraph align="right">This is a right aligned paragraph.</paragraph>
   <paragraph align="justify">This is a justified paragraph.</paragraph>
   <paragraph align="unsupported">This is a paragraph with unsupported align attribute.</paragraph>
+  <paragraph align="LEFT">this is a paragraph with translated valid align attribute.</paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/002-para.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/002-para.xml
@@ -11,5 +11,5 @@
   <paragraph align="right">This is a right aligned paragraph.</paragraph>
   <paragraph align="justify">This is a justified paragraph.</paragraph>
   <paragraph align="unsupported">This is a paragraph with unsupported align attribute.</paragraph>
-  <paragraph align="LEFT">this is a paragraph with translated valid align attribute.</paragraph>
+  <paragraph align="LEFT">This is a paragraph with translated valid align attribute.</paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/022-embed.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/022-embed.xml
@@ -8,4 +8,7 @@
   <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
     <embed xhtml:id="embed-id-2" node_id="601" view="line" class="embedClass2" align="right"/>
   </paragraph>
+  <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+    <embed xhtml:id="embed-id-3" node_id="601" view="line" class="embedClass2" align="custom"/>
+  </paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/024-template.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/024-template.xml
@@ -38,4 +38,7 @@
   <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
     <custom name="factoidbox" custom:class="templateClass4" custom:align="center"/>
   </paragraph>
+  <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+    <custom name="factoidbox" custom:class="templateClass4" custom:align="custom2"/>
+  </paragraph>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30507](https://jira.ez.no/browse/EZP-30507)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

There is a strict list of possible values for ezxhtml:textalign: https://github.com/ezsystems/ezplatform-richtext/blob/master/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng#L744-L756.

So custom values there were causing validation errors. This PR fixes it.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.