### PR TITLE
EZP-30513: eZXMLText Migration: ignore nested embeds in the link

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -617,6 +617,9 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="link/embed|link/embed-inline">
+  </xsl:template>
+
   <xsl:template name="addEmbedLinkAttributes">
     <xsl:variable name="fragment">
       <xsl:if test="@ezlegacytmp-embed-link-anchor_name != ''">

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/014-link.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/014-link.xml
@@ -21,4 +21,7 @@
     <link xlink:href="ezcontent://333" xlink:show="none" xml:id="id5" xlink:title="Content title" ezxhtml:class="linkClass5">Content name</link>
   </para>
   <para><anchor xml:id="anchor"/>Some anchored content.</para>
+  <para>
+    <link xlink:href="ezcontent://333" xlink:show="none" xml:id="id7">link with nested embed</link>
+  </para>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/014-link.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/014-link.xml
@@ -21,4 +21,7 @@
     <link object_id="333" xhtml:id="id5" xhtml:title="Content title" class="linkClass5">Content name</link>
   </paragraph>
   <paragraph><anchor name="anchor"/>Some anchored content.</paragraph>
+  <paragraph>
+    <link object_id="333" xhtml:id="id7">Link with nested embed<embed-inline view="embed-inline" size="original" object_id="444"/></link>
+  </paragraph>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/014-link.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/014-link.xml
@@ -22,6 +22,6 @@
   </paragraph>
   <paragraph><anchor name="anchor"/>Some anchored content.</paragraph>
   <paragraph>
-    <link object_id="333" xhtml:id="id7">Link with nested embed<embed-inline view="embed-inline" size="original" object_id="444"/></link>
+    <link object_id="333" xhtml:id="id7">link with nested embed<embed-inline view="embed-inline" size="original" object_id="444"/></link>
   </paragraph>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30513](https://jira.ez.no/browse/EZP-30513)
| **Type**           | Improvement
| **Target version** | `1.7`
| **BC breaks**      | no
| **Doc needed**     | no

We found that in some cases there might be nested `embed-inline` elements inside `link` in eZ XML Text:
```xml
<link node_id="333">some text
  <embed-inline view="embed-inline" size="original" object_id="444"/>
</link>
```

And it will be converted to invalid RichText:
```xml
<link xlink:href="ezlocation://333" xlink:show="none">some text
  <ezembedinline xlink:href="ezcontent://444" view="embed-inline">
    <ezlink xlink:href="ezlocation://333" xlink:show="none"/>
    <ezconfig>
      <ezvalue key="size">original</ezvalue>
    </ezconfig>
  </ezembedinline>
</link>
```

Such kind embeds need to be ignored.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review