### PR TITLE
Script to generate custom tag configurations

### DIFF
--- a/bundle/Command/GenerateConfigurationCommand.php
+++ b/bundle/Command/GenerateConfigurationCommand.php
@@ -405,8 +405,8 @@ class GenerateConfigurationCommand extends Command
                 $customClasses[self::$elementsMap[$element]] = [
                     'choices' => $classes,
                     'default_value' => $classes[0],
-                    'required' => 'false',
-                    'multiple' => 'false',
+                    'required' => false,
+                    'multiple' => false,
                 ];
             }
 

--- a/bundle/Command/GenerateConfigurationCommand.php
+++ b/bundle/Command/GenerateConfigurationCommand.php
@@ -30,12 +30,12 @@ class GenerateConfigurationCommand extends Command
         'config-file' => [
             'mode' => InputOption::VALUE_OPTIONAL,
             'description' => 'Path where configurations file will be generated',
-            'default' => 'app/config/custom_tags.yml'
+            'default' => 'app/config/custom_tags.yml',
         ],
         'override-config' => [
             'mode' => InputOption::VALUE_NONE,
-            'description' => 'If specified configuration file exists, this option is required to update it'
-        ]
+            'description' => 'If specified configuration file exists, this option is required to update it',
+        ],
     ];
 
     /**
@@ -88,7 +88,6 @@ class GenerateConfigurationCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
         $this->io = new SymfonyStyle($input, $output);
 
         $file = $input->getOption('config-file');
@@ -97,12 +96,13 @@ class GenerateConfigurationCommand extends Command
             $this->checkConfigFile($file, $override);
         } catch (Exception $e) {
             $this->io->error($e->getMessage());
+
             return;
         }
 
         $config = $this->getCustomTagsConfig();
         $this->saveConfig($file, $config);
-        $this->io->success('Configurations are saved for ' . count($config) . ' custom tags into "' . $file . '"');
+        $this->io->success('Configurations are saved for ' . \count($config) . ' custom tags into "' . $file . '"');
     }
 
     /**
@@ -115,13 +115,13 @@ class GenerateConfigurationCommand extends Command
      */
     protected function checkConfigFile(string $file, bool $override = false): void
     {
-        $dir = dirname($file);
-        if (is_writeable($dir) === false) {
-            throw new Exception('Path "' . $dir .'" is not writable');
+        $dir = \dirname($file);
+        if (is_writable($dir) === false) {
+            throw new Exception('Path "' . $dir . '" is not writable');
         }
 
         if (file_exists($file) && $override === false) {
-            throw new Exception('File "' . $file .'" exists, please use --override-config option or provide another --config-file');
+            throw new Exception('File "' . $file . '" exists, please use --override-config option or provide another --config-file');
         }
     }
 
@@ -151,11 +151,11 @@ class GenerateConfigurationCommand extends Command
                     $tags[$tag] = [];
                 }
 
-                $attributes= $xpath->query("*[local-name()='ezconfig']/*[local-name()='ezvalue'][@key]", $element);
+                $attributes = $xpath->query("*[local-name()='ezconfig']/*[local-name()='ezvalue'][@key]", $element);
                 foreach ($attributes as $attribute) {
                     $attr = $attribute->getAttribute('key');
 
-                    if (in_array($attr, $tags[$tag])) {
+                    if (\in_array($attr, $tags[$tag])) {
                         continue;
                     }
 
@@ -170,6 +170,7 @@ class GenerateConfigurationCommand extends Command
 
         return $tags;
     }
+
     /**
      * Fetches Rich Text attributes for published versions only.
      *
@@ -214,7 +215,7 @@ class GenerateConfigurationCommand extends Command
                 'template' => '@ezdesign/custom_tag/' . $customTag . '.html.twig',
                 'icon' => '/bundles/app/img/custom-tag-icons.svg#' . $customTag,
                 'is_inline' => false,
-                'attributes' => []
+                'attributes' => [],
             ];
 
             foreach ($attributes as $attribute) {
@@ -228,11 +229,11 @@ class GenerateConfigurationCommand extends Command
                 'default' => [
                     'fieldtypes' => [
                         'ezrichtext' => [
-                            'custom_tags' => array_keys($customTags)
-                        ]
-                    ]
-                ]
-            ]
+                            'custom_tags' => array_keys($customTags),
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         $yaml = Yaml::dump($parameters, 7);

--- a/bundle/Command/GenerateConfigurationCommand.php
+++ b/bundle/Command/GenerateConfigurationCommand.php
@@ -6,8 +6,6 @@ use DOMDocument;
 use DOMXpath;
 use Exception;
 use PDO;
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\PDOStatement;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,7 +20,22 @@ class GenerateConfigurationCommand extends Command
     /**
      * @var string
      */
-    protected static $defaultName = 'ezxmltext:generate-custom-tags-configuration';
+    protected static $defaultName = 'ezxmltext:generate-configuration';
+
+    /**
+     * https://doc.ezplatform.com/en/latest/guide/extending_online_editor/#custom-data-attributes-and-classes.
+     *
+     * @var array
+     */
+    protected static $elementsMap = [
+        'ul' => 'ul',
+        'ol' => 'ol',
+        'li' => 'li',
+        'p' => 'paragraph',
+        'table' => 'table',
+        'tr' => 'tr',
+        'td' => 'td',
+    ];
 
     /**
      * @var array
@@ -37,6 +50,18 @@ class GenerateConfigurationCommand extends Command
             'mode' => InputOption::VALUE_NONE,
             'description' => 'If specified configuration file exists, this option is required to update it',
         ],
+        'skip-custom-classes' => [
+            'mode' => InputOption::VALUE_NONE,
+            'description' => 'Custom classes will be skipped, if this option is set',
+        ],
+        'skip-custom-attributes' => [
+            'mode' => InputOption::VALUE_NONE,
+            'description' => 'Custom attributes will be skipped, if this option is set',
+        ],
+        'skip-custom-tags' => [
+            'mode' => InputOption::VALUE_NONE,
+            'description' => 'Custom tags will be skipped, if this option is set',
+        ],
     ];
 
     /**
@@ -48,7 +73,6 @@ class GenerateConfigurationCommand extends Command
      * @var Converter
      */
     private $converter;
-
 
     /**
      * @var SymfonyStyle
@@ -72,7 +96,7 @@ class GenerateConfigurationCommand extends Command
      */
     protected function configure(): void
     {
-        $this->setDescription('Generates configuration for converted custom tags');
+        $this->setDescription('Generates Rich Text configuration');
 
         foreach ($this->options as $name => $info) {
             $default = $info['default'] ?? null;
@@ -102,9 +126,52 @@ class GenerateConfigurationCommand extends Command
             return;
         }
 
-        $config = $this->getCustomTagsConfig();
-        $this->saveConfig($file, $config);
-        $this->io->success('Configurations are saved for ' . \count($config) . ' custom tags into "' . $file . '"');
+        $skipCustomClasses = $input->getOption('skip-custom-classes');
+        $skipCustomAttributes = $input->getOption('skip-custom-attributes');
+        $skipCustomTags = $input->getOption('skip-custom-tags');
+        if ($skipCustomClasses && $skipCustomAttributes && $skipCustomTags) {
+            $this->io->error('There is nothing to process as custom attributes/classes and custom tags are skipped');
+
+            return;
+        }
+
+        $config = $this->getConfig($skipCustomClasses, $skipCustomAttributes, $skipCustomTags);
+        $lines = [
+            $this->getConfigStatistics($config['custom_classes'] ?? [], 'custom classes'),
+            $this->getConfigStatistics($config['custom_attributes'] ?? [], 'custom attributes'),
+            $this->getConfigStatistics($config['custom_tags'] ?? [], 'custom tags'),
+        ];
+        foreach ($lines as $line) {
+            $this->io->note($line);
+        }
+
+        if (\count($config) > 0) {
+            $this->saveConfig($file, $config);
+            $this->io->success('Configurations are saved into "' . $file . '"');
+        }
+    }
+
+    /**
+     * Returns string statistics for config definitions.
+     *
+     * @param array $definitions
+     * @param string $title
+     *
+     * @return string
+     */
+    protected function getConfigStatistics(array $definitions, string $title): string
+    {
+        $count = \count($definitions);
+        $output = 'Found ' . $count . ' elements with ' . $title;
+
+        if ($count > 0) {
+            $elements = \is_array(array_values($definitions)[0])
+                ? array_keys($definitions)
+                : $definitions;
+            $output .= ': ' . implode(', ', $elements);
+        }
+
+        return $output;
     }
 
     /**
@@ -128,6 +195,131 @@ class GenerateConfigurationCommand extends Command
     }
 
     /**
+     * Fetches the configuration.
+     *
+     * @param bool $skipClasses
+     * @param bool $skipAttributes
+     * @param bool $skipCustomTags
+     *
+     * @return array
+     */
+    protected function getConfig(
+        bool $skipClasses = false,
+        bool $skipAttributes = false,
+        bool $skipCustomTags = false
+    ): array {
+        $config = [];
+
+        if ($skipClasses === false) {
+            $config['custom_classes'] = $this->getCustomClassesConfig();
+        }
+
+        if ($skipAttributes === false) {
+            $config['custom_attributes'] = $this->getCustomAttributesConfig();
+        }
+
+        if ($skipCustomTags === false) {
+            $config['custom_tags'] = $this->getCustomTagsConfig();
+        }
+
+        return $config;
+    }
+
+    /**
+     * Fetches the configuration for custom classes.
+     *
+     * @return array
+     */
+    protected function getCustomClassesConfig(): array
+    {
+        $this->io->title('Extracting Custom Classes from Rich Text fields');
+
+        $classes = [];
+        $excludeElements = ['div', 'span'];
+
+        $statement = $this->gateway->getRichTextAttributes('class');
+        $this->io->progressStart($statement->rowCount());
+        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+            try {
+                $xpath = $this->getRichTextContentXpath($row['data_text']);
+            } catch (Exception $e) {
+                continue;
+            }
+
+            $elements = $xpath->query('//*[@class]');
+            foreach ($elements as $element) {
+                $tag = $element->nodeName;
+                if (\in_array($tag, $excludeElements)) {
+                    continue;
+                }
+
+                $elementCssClasses = explode(' ', $element->getAttribute('class'));
+                foreach ($elementCssClasses as $class) {
+                    if (isset($classes[$tag]) === false) {
+                        $classes[$tag] = [];
+                    }
+
+                    if (\in_array($class, $classes[$tag])) {
+                        continue;
+                    }
+
+                    $classes[$tag][] = $class;
+                }
+            }
+
+            $this->io->progressAdvance();
+        }
+
+        $this->io->progressFinish();
+
+        return $classes;
+    }
+
+    /**
+     * Fetches the configuration for custom attributes.
+     *
+     * @return array
+     */
+    protected function getCustomAttributesConfig(): array
+    {
+        $this->io->title('Extracting Custom Attributes from Rich Text fields');
+
+        $attributes = [];
+
+        $statement = $this->gateway->getRichTextAttributes('ezvalue');
+        $this->io->progressStart($statement->rowCount());
+        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+            try {
+                $xpath = $this->getRichTextContentXpath($row['data_text']);
+            } catch (Exception $e) {
+                continue;
+            }
+
+            $elements = $xpath->query("//@*[starts-with(local-name(),'data-ezattribute-')]");
+            foreach ($elements as $element) {
+                $attr = str_replace('data-ezattribute-', '', $element->nodeName);
+                $tag = $element->parentNode->nodeName;
+
+                if (isset($attributes[$tag]) === false) {
+                    $attributes[$tag] = [];
+                }
+
+                if (isset($attributes[$tag][$attr])) {
+                    continue;
+                }
+
+                $attributes[$tag][$attr] = ['type' => 'text'];
+            }
+
+            $this->io->progressAdvance();
+        }
+
+        $this->io->progressFinish();
+
+        return $attributes;
+    }
+
+    /**
      * Fetches the configuration for custom tags.
      *
      * @return array
@@ -141,11 +333,9 @@ class GenerateConfigurationCommand extends Command
         $statement = $this->gateway->getRichTextAttributes('eztemplate');
         $this->io->progressStart($statement->rowCount());
         while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-            $xml = new DOMDocument();
-            $xml->loadXML($row['data_text']);
-            $xpath = new DOMXpath($xml);
-
+            $xpath = $this->getRichTextContentXpath($row['data_text'], false);
             $elements = $xpath->query("*[local-name()='eztemplate'][@name]");
+
             foreach ($elements as $element) {
                 $tag = $element->getAttribute('name');
 
@@ -174,6 +364,26 @@ class GenerateConfigurationCommand extends Command
     }
 
     /**
+     * Converts Rich Text content to HTML5 edit, and get its DOMXpath object.
+     *
+     * @param string $content XML content
+     * @param bool $htmlEdit
+     *
+     * @return DOMXpath
+     */
+    protected function getRichTextContentXpath(string $content, bool $htmlEdit = true): DOMXpath
+    {
+        $xml = new DOMDocument();
+        $xml->loadXML($content);
+
+        if ($htmlEdit) {
+            $xml = $this->converter->convert($xml);
+        }
+
+        return new DOMXpath($xml);
+    }
+
+    /**
      * Saves the config.
      *
      * @param string $file
@@ -182,35 +392,78 @@ class GenerateConfigurationCommand extends Command
     protected function saveConfig(string $file, array $config): void
     {
         $parameters = [];
+        $richTextParams = [];
 
-        $customTags = [];
-        foreach ($config as $customTag => $attributes) {
-            $customTags[$customTag] = [
-                'template' => '@ezdesign/custom_tag/' . $customTag . '.html.twig',
-                'icon' => '/bundles/app/img/custom-tag-icons.svg#' . $customTag,
-                'is_inline' => false,
-                'attributes' => [],
-            ];
+        // Custom Classes
+        if (isset($config['custom_classes']) && \count($config['custom_classes']) > 0) {
+            $customClasses = [];
+            foreach ($config['custom_classes'] as $element => $classes) {
+                if (isset(self::$elementsMap[$element]) === false) {
+                    continue;
+                }
 
-            foreach ($attributes as $attribute) {
-                $customTags[$customTag]['attributes'][$attribute] = ['type' => 'string'];
+                $customClasses[self::$elementsMap[$element]] = [
+                    'choices' => $classes,
+                    'default_value' => $classes[0],
+                    'required' => 'false',
+                    'multiple' => 'false',
+                ];
+            }
+
+            if (\count($customClasses) > 0) {
+                $richTextParams['classes'] = $customClasses;
             }
         }
 
-        $parameters['ezrichtext']['custom_tags'] = $customTags;
+        // Custom Attributes
+        if (isset($config['custom_attributes']) && \count($config['custom_attributes']) > 0) {
+            $customAttributes = [];
+            foreach ($config['custom_attributes'] as $element => $attributes) {
+                if (isset(self::$elementsMap[$element]) === false) {
+                    continue;
+                }
+
+                $customAttributes[self::$elementsMap[$element]] = $attributes;
+            }
+
+            if (\count($customAttributes) > 0) {
+                $richTextParams['attributes'] = $customAttributes;
+            }
+        }
+
+        // Custom Tags
+        if (isset($config['custom_tags']) && \count($config['custom_tags']) > 0) {
+            $customTags = [];
+            foreach ($config['custom_tags'] as $customTag => $attributes) {
+                $customTags[$customTag] = [
+                    'template' => '@ezdesign/custom_tag/' . $customTag . '.html.twig',
+                    'icon' => '/bundles/app/img/custom-tag-icons.svg#' . $customTag,
+                    'is_inline' => false,
+                    'attributes' => [],
+                ];
+
+                foreach ($attributes as $attribute) {
+                    $customTags[$customTag]['attributes'][$attribute] = ['type' => 'string'];
+                }
+            }
+
+            if (\count($customTags) > 0) {
+                $parameters['ezrichtext']['custom_tags'] = $customTags;
+                $richTextParams['custom_tags'] = array_keys($customTags);
+            }
+        }
+
         $parameters['ezpublish'] = [
             'system' => [
                 'default' => [
                     'fieldtypes' => [
-                        'ezrichtext' => [
-                            'custom_tags' => array_keys($customTags),
-                        ],
+                        'ezrichtext' => $richTextParams,
                     ],
                 ],
             ],
         ];
 
-        $yaml = Yaml::dump($parameters, 7);
+        $yaml = Yaml::dump($parameters, 8);
 
         file_put_contents($file, $yaml);
     }

--- a/bundle/Command/GenerateConfigurationCommand.php
+++ b/bundle/Command/GenerateConfigurationCommand.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace EzSystems\EzPlatformXmlTextFieldTypeBundle\Command;
+
+use DOMDocument;
+use DOMXpath;
+use Exception;
+use PDO;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDOStatement;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Yaml\Yaml;
+use EzSystems\EzPlatformRichText\eZ\RichText\Converter;
+
+class GenerateConfigurationCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'ezxmltext:generate-custom-tags-configuration';
+
+    /**
+     * @var array
+     */
+    protected $options = [
+        'config-file' => [
+            'mode' => InputOption::VALUE_OPTIONAL,
+            'description' => 'Path where configurations file will be generated',
+            'default' => 'app/config/custom_tags.yml'
+        ],
+        'override-config' => [
+            'mode' => InputOption::VALUE_NONE,
+            'description' => 'If specified configuration file exists, this option is required to update it'
+        ]
+    ];
+
+    /**
+     * @var Connection
+     */
+    protected $db;
+
+    /**
+     * @var Converter
+     */
+    protected $converter;
+
+    /**
+     * @var SymfonyStyle
+     */
+    protected $io;
+
+    /**
+     * @param Connection $db
+     * @param Converter $converter
+     */
+    public function __construct(Connection $db, Converter $converter)
+    {
+        $this->db = $db;
+        $this->converter = $converter;
+
+        parent::__construct();
+    }
+
+    /**
+     * Configures the current command.
+     */
+    protected function configure(): void
+    {
+        $this->setDescription('Generates configuration for converted custom tags');
+
+        foreach ($this->options as $name => $info) {
+            $default = $info['default'] ?? null;
+            $this->addOption($name, null, $info['mode'], $info['description'], $default);
+        }
+    }
+
+    /**
+     * Executes the current command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int|null null or 0 if everything went fine, or an error code
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $this->io = new SymfonyStyle($input, $output);
+
+        $file = $input->getOption('config-file');
+        $override = $input->getOption('override-config');
+        try {
+            $this->checkConfigFile($file, $override);
+        } catch (Exception $e) {
+            $this->io->error($e->getMessage());
+            return;
+        }
+
+        $config = $this->getCustomTagsConfig();
+        $this->saveConfig($file, $config);
+        $this->io->success('Configurations are saved for ' . count($config) . ' custom tags into "' . $file . '"');
+    }
+
+    /**
+     * Checks if results can be stored in specified configuration file.
+     *
+     * @param string $file
+     * @param bool $override
+     *
+     * @throws Exception
+     */
+    protected function checkConfigFile(string $file, bool $override = false): void
+    {
+        $dir = dirname($file);
+        if (is_writeable($dir) === false) {
+            throw new Exception('Path "' . $dir .'" is not writable');
+        }
+
+        if (file_exists($file) && $override === false) {
+            throw new Exception('File "' . $file .'" exists, please use --override-config option or provide another --config-file');
+        }
+    }
+
+    /**
+     * Fetches the configuration for custom tags.
+     *
+     * @return array
+     */
+    protected function getCustomTagsConfig(): array
+    {
+        $this->io->title('Extracting Custom Tags from Rich Text fields');
+
+        $tags = [];
+
+        $statement = $this->getRichTextAttributes('eztemplate');
+        $this->io->progressStart($statement->rowCount());
+        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+            $xml = new DOMDocument();
+            $xml->loadXML($row['data_text']);
+            $xpath = new DOMXpath($xml);
+
+            $elements = $xpath->query("*[local-name()='eztemplate'][@name]");
+            foreach ($elements as $element) {
+                $tag = $element->getAttribute('name');
+
+                if (isset($tags[$tag]) === false) {
+                    $tags[$tag] = [];
+                }
+
+                $attributes= $xpath->query("*[local-name()='ezconfig']/*[local-name()='ezvalue'][@key]", $element);
+                foreach ($attributes as $attribute) {
+                    $attr = $attribute->getAttribute('key');
+
+                    if (in_array($attr, $tags[$tag])) {
+                        continue;
+                    }
+
+                    $tags[$tag][] = $attr;
+                }
+            }
+
+            $this->io->progressAdvance();
+        }
+
+        $this->io->progressFinish();
+
+        return $tags;
+    }
+    /**
+     * Fetches Rich Text attributes for published versions only.
+     *
+     * @param string|null $filterBy Is used to filter Rich Text attributes by content
+     *
+     * @return PDOStatement
+     */
+    protected function getRichTextAttributes(string $filterBy = null): PDOStatement
+    {
+        $query = $this->db->createQueryBuilder();
+        $query->select('a.data_text', 'a.version', 'o.id')
+            ->from('ezcontentobject_attribute', 'a')
+            ->leftJoin('a', 'ezcontentobject', 'o', 'o.id = a.contentobject_id AND o.current_version = a.version')
+            ->where($query->expr()->andx(
+                $query->expr()->eq('a.data_type_string', ':data_type_string'),
+                $query->expr()->isNotNull('o.id')
+            ))
+            ->orderBy('a.id')
+            ->setParameter('data_type_string', 'ezrichtext');
+
+        if ($filterBy !== null) {
+            $condition = $query->expr()->like('a.data_text', ':custom_attributes_element');
+            $query->andWhere($condition)->setParameter('custom_attributes_element', '%' . $filterBy . '%');
+        }
+
+        return $query->execute();
+    }
+
+    /**
+     * Saves the config.
+     *
+     * @param string $file
+     * @param array $config
+     */
+    protected function saveConfig(string $file, array $config): void
+    {
+        $parameters = [];
+
+        $customTags = [];
+        foreach ($config as $customTag => $attributes) {
+            $customTags[$customTag] = [
+                'template' => '@ezdesign/custom_tag/' . $customTag . '.html.twig',
+                'icon' => '/bundles/app/img/custom-tag-icons.svg#' . $customTag,
+                'is_inline' => false,
+                'attributes' => []
+            ];
+
+            foreach ($attributes as $attribute) {
+                $customTags[$customTag]['attributes'][$attribute] = ['type' => 'string'];
+            }
+        }
+
+        $parameters['ezrichtext']['custom_tags'] = $customTags;
+        $parameters['ezpublish'] = [
+            'system' => [
+                'default' => [
+                    'fieldtypes' => [
+                        'ezrichtext' => [
+                            'custom_tags' => array_keys($customTags)
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $yaml = Yaml::dump($parameters, 7);
+
+        file_put_contents($file, $yaml);
+    }
+}

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -39,7 +39,7 @@ services:
     ezxmltext.command.generate_configuration:
         class: EzSystems\EzPlatformXmlTextFieldTypeBundle\Command\GenerateConfigurationCommand
         arguments:
-            - "@database_connection"
+            - "@ezxmltext.persistence.legacy.content_model_gateway"
             - "@ezrichtext.converter.edit.xhtml5"
         tags:
             - { name: console.command }

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -36,6 +36,14 @@ services:
         tags:
             -  { name: console.command }
 
+    ezxmltext.command.generate_configuration:
+        class: EzSystems\EzPlatformXmlTextFieldTypeBundle\Command\GenerateConfigurationCommand
+        arguments:
+            - "@database_connection"
+            - "@ezrichtext.converter.edit.xhtml5"
+        tags:
+            - { name: console.command }
+
     ezxmltext.richtext_converter:
         class: eZ\Publish\Core\FieldType\XmlText\Converter\RichText
         arguments:

--- a/lib/FieldType/XmlText/Persistence/Legacy/ContentModelGateway.php
+++ b/lib/FieldType/XmlText/Persistence/Legacy/ContentModelGateway.php
@@ -5,6 +5,7 @@
 namespace eZ\Publish\Core\FieldType\XmlText\Persistence\Legacy;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDOStatement;
 use PDO;
 
 class ContentModelGateway
@@ -294,5 +295,33 @@ class ContentModelGateway
             ->setParameter(':version', $version)
             ->setParameter(':language', $language);
         $updateQuery->execute();
+    }
+
+    /**
+     * Fetches Rich Text attributes for published versions only.
+     *
+     * @param string|null $filterBy Is used to filter Rich Text attributes by content
+     *
+     * @return PDOStatement
+     */
+    public function getRichTextAttributes(string $filterBy = null): PDOStatement
+    {
+        $query = $this->dbal->createQueryBuilder();
+        $query->select('a.data_text', 'a.version', 'o.id')
+            ->from('ezcontentobject_attribute', 'a')
+            ->leftJoin('a', 'ezcontentobject', 'o', 'o.id = a.contentobject_id AND o.current_version = a.version')
+            ->where($query->expr()->andx(
+                $query->expr()->eq('a.data_type_string', ':data_type_string'),
+                $query->expr()->isNotNull('o.id')
+            ))
+            ->orderBy('a.id')
+            ->setParameter('data_type_string', 'ezrichtext');
+
+        if ($filterBy !== null) {
+            $condition = $query->expr()->like('a.data_text', ':custom_attributes_element');
+            $query->andWhere($condition)->setParameter('custom_attributes_element', '%' . $filterBy . '%');
+        }
+
+        return $query->execute();
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Type**           | Feature
| **Target version** | `1.9`
| **BC breaks**      | no
| **Doc needed**     | yes

The script which generates the configuration for migrated custom tags. Usage:
```
$ php bin/console ezxmltext:generate-configuration

Extracting Custom Classes from Rich Text fields
===============================================

 11698/11698 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

Extracting Custom Attributes from Rich Text fields
==================================================

 477/477 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

Extracting Custom Tags from Rich Text fields
============================================

 197/197 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ! [NOTE] Found 2 elements with custom classes: table, a                                                                

 ! [NOTE] Found 1 elements with custom attributes: a                                                                    

 ! [NOTE] Found 8 elements with custom tags: content-block, pull-quote, youtube-video, icon-list, rawhtml,              
 !        accordion-group, callout, hr 

 [OK] Configurations are saved into "app/config/custom_tags.yml"                                
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
