### PR TITLE
Custom attributes support in paragraph tags

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/schemas/ezxml.xsd
+++ b/lib/FieldType/XmlText/Input/Resources/schemas/ezxml.xsd
@@ -34,6 +34,7 @@
     </xs:choice>
     <xs:attributeGroup ref="align"/>
     <xs:attributeGroup ref="class"/>
+    <xs:anyAttribute namespace="http://ez.no/namespaces/ezpublish3/custom/" processContents="skip"/>
   </xs:complexType>
 
   <xs:complexType name="header" mixed="true">


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | ezplatform-xmltext-fieldtype issue #101
| **Type**           | Bug
| **Target version** | latest stable `1.8` for bug fixes, `master` for new features
| **BC breaks**      | no
| **Doc needed**     | no

Supports custom attributes support in paragraph tags during XML schema validation.

- [X] Implement feature / fix a bug.
- [ ] Implement tests + specs and passing (`$ composer test`)
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
