### PR TITLE
No align attribute for custom tags

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -28,11 +28,6 @@
           <xsl:value-of select="@custom:class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@custom:align">
-        <xsl:attribute name="ezxhtml:align">
-          <xsl:value-of select="translate(@custom:align, $uppercase, $lowercase)"/>
-        </xsl:attribute>
-      </xsl:if>
       <xsl:if test="./text()">
         <xsl:element name="ezcontent" namespace="http://docbook.org/ns/docbook">
           <xsl:apply-templates/>
@@ -58,11 +53,6 @@
       <xsl:if test="@custom:class">
         <xsl:attribute name="ezxhtml:class">
           <xsl:value-of select="@custom:class"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@custom:align">
-        <xsl:attribute name="ezxhtml:align">
-          <xsl:value-of select="translate(@custom:align, $uppercase, $lowercase)"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="./* | ./text()">

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/024-template.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/024-template.xml
@@ -4,7 +4,7 @@
          xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
          xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
          version="5.0-variant ezpublish-1.0">
-  <eztemplate name="factbox" ezxhtml:class="templateClass" ezxhtml:align="left">
+  <eztemplate name="factbox" ezxhtml:class="templateClass">
     <ezcontent>
       <table title="tableTitle">
         <ezattribute>
@@ -35,7 +35,7 @@
       <ezvalue key="title">Factoids</ezvalue>
     </ezconfig>
   </eztemplate>
-  <eztemplate name="externalimage" ezxhtml:class="templateClass2" ezxhtml:align="right">
+  <eztemplate name="externalimage" ezxhtml:class="templateClass2">
     <ezconfig>
       <ezvalue key="src">http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif</ezvalue>
       <ezvalue key="height">365</ezvalue>
@@ -44,8 +44,8 @@
       <ezvalue key="caption">bistable multivibrator</ezvalue>
     </ezconfig>
   </eztemplate>
-  <eztemplate name="factoidbox" ezxhtml:class="templateClass3" ezxhtml:align="center">
+  <eztemplate name="factoidbox" ezxhtml:class="templateClass3">
     <ezcontent>It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</ezcontent>
   </eztemplate>
-  <eztemplate name="factoidbox" ezxhtml:class="templateClass4" ezxhtml:align="center"/>
+  <eztemplate name="factoidbox" ezxhtml:class="templateClass4"/>
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/160-eztemplate.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/160-eztemplate.xml
@@ -4,7 +4,7 @@
         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
         xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
   <eztemplate name="linebreak"/>
-  <eztemplate name="mycustomtag" ezxhtml:align="left" ezxhtml:class="templateClass">
+  <eztemplate name="mycustomtag" ezxhtml:class="templateClass">
     <ezcontent>
             custom tag content
         </ezcontent>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | none
| **Type**           | Bug
| **Target version** | `1.9`
| **BC breaks**      | no
| **Doc needed**     | no

The latest version of https://github.com/ezsystems/ezplatform-richtext does not allow to have `align` attribute for custom tags. It triggers a validation error.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
