### PR TITLE
[Travis] Add swap to avoid hitting memory issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ before_script:
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - mkdir -p ~/.composer
     - cp bin/.travis/composer-auth.json ~/.composer/auth.json
+    # Enable swap to avoid Composer memory issues
+    - sudo /bin/dd if=/dev/zero of=/var/swap.1 bs=1M count=2048
+    - sudo /sbin/mkswap /var/swap.1
+    - sudo /sbin/swapon /var/swap.1
     - composer install --no-progress --no-interaction --prefer-dist
     - if [ "$SOLR_VERSION" != "" ] ; then ./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh ; fi
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Type**           | Misc
| **Target version** | 1.7 - same as https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/96
| **BC breaks**      | no
| **Doc needed**     | no

All PHP 5.6 jobs are failing on Travis because of memory issues, see: https://travis-ci.org/ezsystems/ezplatform-xmltext-fieldtype/builds/566005333?utm_source=github_status&utm_medium=notification

I suppose we could try limiting the minimum supported versions in requirements in this bundle:
```
    "require": {
        "ezsystems/ezpublish-kernel": "^6.11@dev || ^7.0@dev",
        "ezsystems/repository-forms": "^1.9 || ^2.0"
    },
```
but as I don't know with which version is the 1.7 line intended to be used. To avoid preventing users from installing it I've decided to simply add swap for Travis, as described in https://getcomposer.org/doc/articles/troubleshooting.md#proc-open-fork-failed-errors

I've tested the build with 1024 and it still failed, hence 2048 here.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
