### PR TITLE
[Travis] Set dist to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 services:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Type**           | Misc
| **Target version** | 1.7, same as https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/98
| **BC breaks**      | no
| **Doc needed**     | no

Travis switched the default dist from trusty to xenial:
https://travis-ci.org/ezsystems/ezplatform-xmltext-fieldtype/builds/567807165 - uses trusty
https://travis-ci.org/ezsystems/ezplatform-xmltext-fieldtype/builds/569339518 - uses xenial

This is causing the builds in https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/98 to fail.

Setting the dist excplicitly as it is done in 1.8 branch: https://github.com/ezsystems/ezplatform-xmltext-fieldtype/blob/1.8/.travis.yml#L1
