### PR TITLE
 EZP-30513: eZXMLText Migration: link tags containing embed-inline + other elements fails

### DIFF
--- a/lib/FieldType/XmlText/Converter/EmbedLinking.php
+++ b/lib/FieldType/XmlText/Converter/EmbedLinking.php
@@ -31,9 +31,9 @@ class EmbedLinking implements Converter
     public function convert(DOMDocument $document)
     {
         $xpath = new DOMXPath($document);
-        // Select embeds that are linked
+        // Select embeds that are linked ( but only where embed is the only child of the link )
         // After Expanding converter such links will contain only single embed element
-        $xpathExpression = '//embed[parent::link]|//embed-inline[parent::link]';
+        $xpathExpression = '//embed[parent::link][count(preceding-sibling::*)+count(following-sibling::*)=0]|//embed-inline[parent::link][count(preceding-sibling::*)+count(following-sibling::*)=0]';
 
         $linkedEmbeds = $xpath->query($xpathExpression);
 

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/048-link_outside_embed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/048-link_outside_embed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>paragraph text and (
+        <link node_id="333">
+            <embed-inline view="embed-inline" size="original" object_id="444"/>
+        </link>    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/049-link_outside_embeds.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/049-link_outside_embeds.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>paragraph text and (
+        <link node_id="333">Foo
+            <embed-inline view="embed-inline" size="original" object_id="444"/>bar
+            <embed-inline view="embed-inline" size="original" object_id="445"/>2
+        </link>    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/048-link_outside_embed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/048-link_outside_embed.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>paragraph text and (
+        <ezembedinline view="embed-inline" xlink:href="ezcontent://444"><ezlink xlink:href="ezlocation://333" xlink:show="none"/><ezconfig><ezvalue key="size">original</ezvalue></ezconfig></ezembedinline>    </para>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/049-link_outside_embeds.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/049-link_outside_embeds.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>paragraph text and (
+        <link xlink:href="ezlocation://333" xlink:show="none">Foo
+            <ezembedinline xlink:href="ezcontent://444" view="embed-inline"><ezconfig><ezvalue key="size">original</ezvalue></ezconfig></ezembedinline>bar
+            <ezembedinline xlink:href="ezcontent://445" view="embed-inline"><ezconfig><ezvalue key="size">original</ezvalue></ezconfig></ezembedinline>2
+        </link>    </para>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30513](https://jira.ez.no/browse/EZP-30513)
| **Type**           | Bug
| **Target version** | 1.7
| **BC breaks**      | no
| **Doc needed**     | no


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
