### PR TITLE
GraphQL query support for ezxml field type

### DIFF
--- a/bundle/GraphQL/Resolver/XmlTextResolver.php
+++ b/bundle/GraphQL/Resolver/XmlTextResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformXmlTextFieldTypeBundle\GraphQL\Resolver;
+
+use DOMDocument;
+use eZ\Publish\Core\FieldType\XmlText\Converter\Html5 as Html5Converter;
+
+/**
+ * @internal
+ */
+class XmlTextResolver
+{
+    /**
+     * @var Html5Converter
+     */
+    private $xmlTextConverter;
+
+    public function __construct(Html5Converter $xmlTextConverter)
+    {
+        $this->xmlTextConverter = $xmlTextConverter;
+    }
+
+    public function xmlTextToHtml5(DOMDocument $document)
+    {
+        return $this->xmlTextConverter->convert($document);
+    }
+}

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -8,3 +8,7 @@ parameters:
         -
             path: "%kernel.root_dir%/../vendor/ezsystems/ezplatform-xmltext-fieldtype/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_custom.xsl"
             priority: 0
+
+    ezplatform_graphql.schema.content.mapping.field_definition_type:
+        ezxmltext:
+            value_type: XmlTextFieldValue

--- a/bundle/Resources/config/graphql/Field.types.yml
+++ b/bundle/Resources/config/graphql/Field.types.yml
@@ -1,0 +1,20 @@
+XmlTextFieldValue:
+    type: object
+    config:
+        fields:
+            text:
+                type: "String"
+                description: "String representation of the value"
+                resolve: "@=value"
+            xml:
+                type: "String"
+                description: "The raw xml"
+                resolve: "@=value"
+            plaintext:
+                type: "String"
+                description: "Plain text representation of the value, without tags. Warning: the text representation may not be perfect."
+                resolve: "@=value.xml.textContent"
+            html5:
+                type: "String"
+                description: "HTML5 representation."
+                resolve: "@=resolver('XmlTextToHtml5', [value.xml])"

--- a/bundle/Resources/config/services.yml
+++ b/bundle/Resources/config/services.yml
@@ -42,3 +42,10 @@ services:
             - "@ezpublish.api.repository"
             - "@?logger"
             - "@ezpublish.fieldType.ezrichtext.validator.docbook"
+
+    ezxmltext.graphql.resolver:
+        class: EzSystems\EzPlatformXmlTextFieldTypeBundle\GraphQL\Resolver\XmlTextResolver
+        arguments:
+            - "@ezpublish.fieldType.ezxmltext.converter.html5"
+        tags:
+            - { name: overblog_graphql.resolver, alias: "XmlTextToHtml5", method: "xmlTextToHtml5" }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | none
| **Type**           | Feature
| **Target version** | latest stable `1.9`
| **BC breaks**      | no
| **Doc needed**     | no

This PR provides full GraphQL _query_ support for `ezxmltext` field types.

Modelled after the richtext field type, it offers these subtypes:

      text:
            type: "String"
            description: "String representation of the value"
        xml:
            type: "String"
            description: "The raw ezxmltext xml"
        plaintext:
            type: "String"
            description: "Plain text representation of the value, without tags. Warning: the text representation may not be perfect."
        html5:
            type: "String"
            description: "HTML5 representation."

Note: mutations are not in the scope of this PR and are not a planned feature.