### PR TITLE
Ensure <eztemplate> elements contains <ezcontent> child

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -65,11 +65,9 @@
           <xsl:with-param name="align" select="@custom:align"/>
         </xsl:call-template>
       </xsl:if>
-      <xsl:if test="./* | ./text()">
-        <xsl:element name="ezcontent" namespace="http://docbook.org/ns/docbook">
-          <xsl:apply-templates/>
-        </xsl:element>
-      </xsl:if>
+      <xsl:element name="ezcontent" namespace="http://docbook.org/ns/docbook">
+        <xsl:apply-templates/>
+      </xsl:element>
       <xsl:if test="@*[namespace-uri() = 'http://ez.no/namespaces/ezpublish3/custom/' and not( local-name() = 'class' ) and not( local-name() = 'align' )]">
         <xsl:element name="ezconfig" namespace="http://docbook.org/ns/docbook">
           <xsl:for-each select="@*[namespace-uri() = 'http://ez.no/namespaces/ezpublish3/custom/' and not( local-name() = 'class' ) and not( local-name() = 'align' )]">

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/024-template.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/024-template.xml
@@ -32,6 +32,7 @@
     </ezconfig>
   </eztemplate>
   <eztemplate name="externalimage" ezxhtml:class="templateClass2" ezxhtml:align="right">
+    <ezcontent/>
     <ezconfig>
       <ezvalue key="src">http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif</ezvalue>
       <ezvalue key="height">365</ezvalue>
@@ -43,6 +44,11 @@
   <eztemplate name="factoidbox" ezxhtml:class="templateClass3" ezxhtml:align="center">
     <ezcontent>It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</ezcontent>
   </eztemplate>
-  <eztemplate name="factoidbox" ezxhtml:class="templateClass4" ezxhtml:align="center"/>
-  <eztemplate name="factoidbox" ezxhtml:class="templateClass4"/>
+  <eztemplate name="factoidbox" ezxhtml:class="templateClass4" ezxhtml:align="center">
+  <ezcontent/>
+  </eztemplate>
+  <eztemplate name="factoidbox" ezxhtml:class="templateClass4">
+  <ezcontent/>
+  </eztemplate>
+
 </section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/161-eztemplate-no-content.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/161-eztemplate-no-content.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/">
+    <section>
+        <custom name="linebreak"/>
+    </section>
+    <!-- xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"-->
+    <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+        <custom name="mycustomtag" custom:class="templateClass" custom:align="left" custom:title="foobar"/>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/log/161-eztemplate-no-content.log
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/log/161-eztemplate-no-content.log
@@ -1,0 +1,1 @@
+warning:Custom tag 'linebreak' converted to block custom tag. It might have been inline custom tag in legacy DB where contentobject_attribute.id=

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/161-eztemplate-no-content.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/161-eztemplate-no-content.xml
@@ -3,16 +3,14 @@
         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
         xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
-  <eztemplate name="linebreak">
+    <eztemplate name="linebreak">
     <ezcontent/>
-  </eztemplate>
-  <eztemplate name="mycustomtag" ezxhtml:align="left" ezxhtml:class="templateClass">
-    <ezcontent>
-            custom tag content
-        </ezcontent>
-    <ezconfig>
-      <ezvalue key="title">foobar</ezvalue>
-    </ezconfig>
-  </eztemplate>
+    </eztemplate>
+    <eztemplate name="mycustomtag" ezxhtml:align="left" ezxhtml:class="templateClass">
+        <ezcontent/>
+        <ezconfig>
+            <ezvalue key="title">foobar</ezvalue>
+        </ezconfig>
+    </eztemplate>
 </section>
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     |     [EZP-31130 : {{ content }} variable not always available in twig template for custom tag](https://jira.ez.no/browse/EZP-31130)
| **Type**           | Improvement
| **Target version** | 1.8
| **BC breaks**      | no
| **Doc needed**     | no

This change is to ensure conversion script creates customtags in the same way as admin-ui ( even though the previous behaviour also was also valid schema wise). admin-ui always creates a `<ezcontent/>` element below `eztemplate`, even though the custom tags has no content..

eZ Platform version 2.5.6 and earlier will give fatal error on the following twig code for `<eztemplate>`  elements which has no `<ezcontent/>` sub element:

```
{{ content|raw }}
```

See https://github.com/ezsystems/ezplatform-richtext/pull/84 for more info.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
