### PR TITLE
EZP-31474 - fix embed anchor link converting to richtext

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -677,6 +677,13 @@
           <xsl:value-of select="concat( 'ezcontent://', @ezlegacytmp-embed-link-object_id, $fragment )"/>
         </xsl:attribute>
       </xsl:when>
+      <xsl:otherwise>
+        <xsl:if test="$fragment">
+          <xsl:attribute name="xlink:href">
+            <xsl:value-of select="$fragment"/>
+          </xsl:attribute>
+        </xsl:if>
+      </xsl:otherwise>
     </xsl:choose>
     <xsl:if test="@ezlegacytmp-embed-link-url_id or @ezlegacytmp-embed-link-node_id or @ezlegacytmp-embed-link-object_id">
       <xsl:attribute name="xlink:show">

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/027-linkedEmbed.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/027-linkedEmbed.xml
@@ -4,6 +4,10 @@
          xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
          xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
          version="5.0-variant ezpublish-1.0">
+  <ezembed xlink:href="ezlocation://241190">
+    <ezlink xlink:href="#maincontent"/>
+    <ezconfig><ezvalue key="size">original</ezvalue></ezconfig>
+  </ezembed>
   <ezembed xlink:href="ezcontent://106" view="embed" xml:id="embed-id-1" ezxhtml:class="embed-class" ezxhtml:align="left">
     <ezlink xlink:href="ezurl://95#fragment1" xlink:show="new" xml:id="link-id-1" xlink:title="Link title" ezxhtml:class="link-class"/>
     <ezconfig>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/027-linkedEmbed.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/027-linkedEmbed.xml
@@ -3,6 +3,11 @@
          xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
          xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
   <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+    <link anchor_name="maincontent">
+      <embed size="original" align="top" node_id="241190"/>
+    </link>
+  </paragraph>
+  <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
     <link xhtml:id="link-id-1" url_id="95" anchor_name="fragment1" target="_blank" xhtml:title="Link title" class="link-class">
       <embed xhtml:id="embed-id-1" object_id="106" view="embed" size="medium" class="embed-class" align="left" custom:offset="10" custom:limit="5"/>
     </link>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31474](https://jira.ez.no/browse/EZP-31474)
| **Type**           | Bug
| **Target version** | 1.9
| **BC breaks**      | no
| **Doc needed**     | no

Currently, the converter works incorrectly for this XML:
```
<?xml version="1.0" encoding="utf-8"?>
<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
  <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
    <link anchor_name="maincontent">
      <embed size="original" align="top" node_id="241190"/>
    </link>
  </paragraph>
</section>
```

It will result to empty <link/> object inserted into embed
```
<ezembed xlink:href="ezlocation://241190" ezxhtml:class="ez-embed-type-image">
	<ezlink/>
	<ezconfig><ezvalue key="size">original</ezvalue>ezconfig>
</ezembed>
```

This PR fixing it, so `<ezlink xlink:href="#maincontent"/>` will be created in converter.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
