### PR TITLE
Upgraded package to be compatible with eZ Platform v3.0

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -19,6 +19,7 @@ return PhpCsFixer\Config::create()
         'yoda_style' => false,
         'no_break_comment' => false,
         'no_superfluous_phpdoc_tags' => false,
+        'native_function_invocation' => false,
 
         // 2019 style updates with cs-fixer 2.14, all above are in sync with kernel
         '@PHPUnit57Migration:risky' => true,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@
 
 This is the XmlText field type for eZ Platform. It was extracted from the eZ Publish / Platform 5.x as it has been suceeded by docbook based [RichText](https://github.com/ezsystems/ezplatform-richtext) field type.
 
-_Note: This Field Type supports editing via Platform UI  v1 / Admin UI v2, however only as raw (simplified) xml. There has currently not been any attempts at getting Online Editor from legacy extension to work with within Platform UI, to do that among other things someone would need to port the custom html to xml handler from oe extension to this field type. So this Field Type is mainly meant for use for migrating to RichText, see below._
+
+### Support limitations
+
+- 2.x: For eZ Platform v3, this bundle is **only** supported for the purpose of migrating content from XmlText to RichText field type
+- 1.x: For eZ Platform v1 & v2, this bundle is supported for two use cases: Migration to Richtext, & rendering via Platform frontend\*.
+
+_* While it does support editing via Platform Admin UI it is only editable as raw xmltext in a textbox, so supported use as of this field type is for temprary upgrde scenarios where legacy admin interface is used, and frontend code is being developed/migrated to eZ Platform stack (including to Symfony)._
 
 
 ## Installation

--- a/bundle/Command/ConvertXmlTextToRichTextCommand.php
+++ b/bundle/Command/ConvertXmlTextToRichTextCommand.php
@@ -1,15 +1,17 @@
 <?php
+
 /**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\EzPlatformXmlTextFieldTypeBundle\Command;
 
+use Doctrine\DBAL\FetchMode;
 use DOMDocument;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\FieldType\XmlText\Converter\RichText as RichTextConverter;
 use eZ\Publish\Core\FieldType\XmlText\Persistence\Legacy\ContentModelGateway as Gateway;
 use eZ\Publish\Core\FieldType\XmlText\Value;
-use PDO;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Command\Command;
@@ -385,7 +387,7 @@ EOT
 
         $statement = $query->execute();
 
-        $columns = $statement->fetchAll(PDO::FETCH_ASSOC);
+        $columns = $statement->fetchAll(FetchMode::ASSOCIATIVE);
         $result = [];
         foreach ($columns as $column) {
             $result[$column['identifier']] = $column['id'];
@@ -414,7 +416,7 @@ EOT
             $limit = self::MAX_OBJECTS_PER_CHILD;
 
             $statement = $this->gateway->getFieldRows('ezrichtext', $contentId, $offset, $limit);
-            while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+            while ($row = $statement->fetch(FetchMode::ASSOCIATIVE)) {
                 if (empty($row['data_text'])) {
                     $inputValue = Value::EMPTY_VALUE;
                 } else {
@@ -623,7 +625,7 @@ EOT
     protected function convertFields($dryRun, $contentId, $checkDuplicateIds, $checkIdValues, $offset, $limit)
     {
         $statement = $this->gateway->getFieldRows(['ezxmltext', 'ezrichtext'], $contentId, $offset, $limit);
-        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+        while ($row = $statement->fetch(FetchMode::ASSOCIATIVE)) {
             if ($row['data_type_string'] === 'ezrichtext') {
                 continue;
             }

--- a/bundle/Command/ConvertXmlTextToRichTextCommand.php
+++ b/bundle/Command/ConvertXmlTextToRichTextCommand.php
@@ -8,6 +8,7 @@ namespace EzSystems\EzPlatformXmlTextFieldTypeBundle\Command;
 
 use Doctrine\DBAL\FetchMode;
 use DOMDocument;
+use ErrorException;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\FieldType\XmlText\Converter\RichText as RichTextConverter;
 use eZ\Publish\Core\FieldType\XmlText\Persistence\Legacy\ContentModelGateway as Gateway;
@@ -21,7 +22,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Debug\Exception\ContextErrorException;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -733,13 +733,13 @@ EOT
         $document->preserveWhiteSpace = false;
         $document->formatOutput = false;
 
-        // In dev mode, symfony may throw Symfony\Component\Debug\Exception\ContextErrorException
+        // In dev mode, symfony may throw \ErrorException
         try {
             $result = $document->loadXml($xmlString);
             if ($result === false) {
                 throw new RuntimeException('Unable to parse ezxmltext. Invalid XML format');
             }
-        } catch (ContextErrorException $e) {
+        } catch (ErrorException $e) {
             throw new RuntimeException($e->getMessage(), $e->getCode());
         }
 

--- a/bundle/Command/ImportXmlCommand.php
+++ b/bundle/Command/ImportXmlCommand.php
@@ -5,6 +5,7 @@
 namespace EzSystems\EzPlatformXmlTextFieldTypeBundle\Command;
 
 use DOMDocument;
+use ErrorException;
 use eZ\Publish\Core\FieldType\XmlText\Converter\RichText as RichTextConverter;
 use eZ\Publish\Core\FieldType\XmlText\Persistence\Legacy\ContentModelGateway as Gateway;
 use Psr\Log\LogLevel;
@@ -13,7 +14,6 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Debug\Exception\ContextErrorException;
 
 class ImportXmlCommand extends Command
 {
@@ -205,13 +205,13 @@ EOT
         $document->preserveWhiteSpace = false;
         $document->formatOutput = false;
 
-        // In dev mode, symfony may throw Symfony\Component\Debug\Exception\ContextErrorException
+        // In dev mode, symfony may throw \ErrorException
         try {
             $result = $document->loadXml($xmlString);
             if ($result === false) {
                 throw new RuntimeException('Unable to parse ezxmltext. Invalid XML format');
             }
-        } catch (ContextErrorException $e) {
+        } catch (ErrorException $e) {
             throw new RuntimeException($e->getMessage(), $e->getCode());
         }
 

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * This file is part of the eZ Platform XmlText Field Type package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -12,6 +10,7 @@ use DOMDocument;
 use DOMElement;
 use DOMNode;
 use DOMXPath;
+use ErrorException;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\FieldType\XmlText\Converter;
@@ -21,7 +20,6 @@ use EzSystems\EzPlatformRichText\eZ\RichText\Validator\Validator;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
-use Symfony\Component\Debug\Exception\ContextErrorException;
 
 class RichText implements Converter
 {
@@ -614,7 +612,7 @@ class RichText implements Converter
         // Needed by some disabled output escaping (eg. legacy ezxml paragraph <line/> elements)
         $convertedDocumentNormalized = new DOMDocument();
         try {
-            // If env=dev, Symfony will throw ContextErrorException on line below if xml is invalid
+            // If env=dev, Symfony will throw \ErrorException on line below if xml is invalid
             $result = $convertedDocumentNormalized->loadXML($convertedDocument->saveXML());
             if ($result === false) {
                 $this->log(LogLevel::ERROR,
@@ -622,7 +620,7 @@ class RichText implements Converter
                     ['result' => $convertedDocument->saveXML(), 'errors' => ['Unable to parse converted richtext output. See warning in logs or use --env=dev in order to se more verbose output.'], 'xmlString' => $inputDocument->saveXML()]
                 );
             }
-        } catch (ContextErrorException $e) {
+        } catch (ErrorException $e) {
             $this->log(LogLevel::ERROR,
                 "Unable to convert ezmltext for contentobject_attribute.id=$contentFieldId",
                 ['result' => $convertedDocument->saveXML(), 'errors' => [$e->getMessage()], 'xmlString' => $inputDocument->saveXML()]

--- a/lib/FieldType/XmlText/Persistence/Legacy/ContentModelGateway.php
+++ b/lib/FieldType/XmlText/Persistence/Legacy/ContentModelGateway.php
@@ -1,11 +1,13 @@
 <?php
+
 /**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\XmlText\Persistence\Legacy;
 
 use Doctrine\DBAL\Connection;
-use PDO;
+use Doctrine\DBAL\FetchMode;
 
 class ContentModelGateway
 {
@@ -35,7 +37,7 @@ class ContentModelGateway
 
         $statement = $query->execute();
 
-        $columns = $statement->fetchAll(PDO::FETCH_ASSOC);
+        $columns = $statement->fetchAll(FetchMode::ASSOCIATIVE);
         $result = [];
         foreach ($columns as $column) {
             $result[$column['identifier']] = $column['id'];

--- a/lib/FieldType/XmlText/SearchField.php
+++ b/lib/FieldType/XmlText/SearchField.php
@@ -60,7 +60,7 @@ class SearchField implements Indexable
     {
         $text = '';
 
-        if ($node->childNodes) {
+        if ($node->childNodes !== null && $node->childNodes->count() > 0) {
             foreach ($node->childNodes as $child) {
                 $text .= $this->extractText($child);
             }

--- a/lib/FieldType/XmlText/XmlTextStorage/Gateway/DoctrineStorage.php
+++ b/lib/FieldType/XmlText/XmlTextStorage/Gateway/DoctrineStorage.php
@@ -1,23 +1,19 @@
 <?php
 
 /**
- * This file is part of the eZ Platform XmlText Field Type package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace eZ\Publish\Core\FieldType\XmlText\XmlTextStorage\Gateway;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
 use DOMDocument;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
 use eZ\Publish\Core\FieldType\XmlText\XmlTextStorage\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
-use PDO;
 
 class DoctrineStorage extends Gateway
 {
@@ -223,7 +219,7 @@ class DoctrineStorage extends Gateway
             );
 
             $statement = $q->execute();
-            foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            foreach ($statement->fetchAll(FetchMode::ASSOCIATIVE) as $row) {
                 $objectRemoteIdMap[$row['remote_id']] = $row['id'];
             }
         }

--- a/tests/lib/FieldType/Persistence/Legacy/BaseTest.php
+++ b/tests/lib/FieldType/Persistence/Legacy/BaseTest.php
@@ -1,82 +1,31 @@
 <?php
+
 /**
- * This file is part of the eZ Platform XmlText Field Type package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Persistence\Legacy;
 
+use Doctrine\DBAL\DBALException;
+use ErrorException;
 use eZ\Publish\API\Repository\Tests\BaseTest as APIBaseTest;
+use eZ\Publish\SPI\Tests\Persistence\FileFixtureFactory;
+use eZ\Publish\SPI\Tests\Persistence\FixtureImporter;
 
 abstract class BaseTest extends APIBaseTest
 {
     /**
-     * Taken from ezplatform-kernel/eZ/Publish/Core/Persistence/Legacy/Tests/TestCase.php.
-     *
      * @param string $file
-     * @throws \Exception
      */
-    protected function insertDatabaseFixture($file)
+    protected function insertDatabaseFixture(string $file): void
     {
-        $data = require $file;
-        $db = $this->getSetupFactory()->getDatabaseHandler();
-
-        foreach ($data as $table => $rows) {
-            // Check that at least one row exists
-            if (!isset($rows[0])) {
-                continue;
-            }
-
-            $q = $db->createInsertQuery();
-            $q->insertInto($db->quoteIdentifier($table));
-
-            // Contains the bound parameters
-            $values = [];
-
-            // Binding the parameters
-            foreach ($rows[0] as $col => $val) {
-                $q->set(
-                    $db->quoteIdentifier($col),
-                    $q->bindParam($values[$col])
-                );
-            }
-
-            $stmt = $q->prepare();
-
-            foreach ($rows as $row) {
-                try {
-                    // This CANNOT be replaced by:
-                    // $values = $row
-                    // each $values[$col] is a PHP reference which should be
-                    // kept for parameters binding to work
-                    foreach ($row as $col => $val) {
-                        $values[$col] = $val;
-                    }
-
-                    $stmt->execute();
-                } catch (Exception $e) {
-                    echo "$table ( ", implode(', ', $row), " )\n";
-                    throw $e;
-                }
-            }
-        }
-
-        $this->resetSequences();
-    }
-
-    public function resetSequences()
-    {
-        switch ($this->getDB()) {
-            case 'pgsql':
-                // Update PostgreSQL sequences
-                $handler = $this->getSetupFactory()->getDatabaseHandler();
-
-                $queries = array_filter(preg_split('(;\\s*$)m',
-                    file_get_contents(__DIR__ . '/_fixtures/setval.pgsql.sql')));
-                foreach ($queries as $query) {
-                    $handler->exec($query);
-                }
+        try {
+            $fixtureImporter = new FixtureImporter($this->getRawDatabaseConnection());
+            $fixtureImporter->import((new FileFixtureFactory())->buildFixture($file));
+        } catch (ErrorException | DBALException $e) {
+            self::fail('Database fixture import failed: ' . $e->getMessage());
         }
     }
 }

--- a/tests/lib/FieldType/Persistence/Legacy/ContentModelGatewayTest.php
+++ b/tests/lib/FieldType/Persistence/Legacy/ContentModelGatewayTest.php
@@ -1,13 +1,16 @@
 <?php
+
 /**
- * This file is part of the eZ Platform XmlText Field Type package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\FieldType\Persistence\Legacy;
 
-use PDO;
+use function count;
+use Doctrine\DBAL\FetchMode;
+use eZ\Publish\Core\FieldType\XmlText\Persistence\Legacy\ContentModelGateway;
 
 class ContentModelGatewayTest extends BaseTest
 {
@@ -17,7 +20,7 @@ class ContentModelGatewayTest extends BaseTest
         $this->getSetupFactory()->resetDB();
     }
 
-    public function getContentTypeIdsProvider()
+    public function getContentTypeIdsProvider(): array
     {
         return [
             [
@@ -33,10 +36,13 @@ class ContentModelGatewayTest extends BaseTest
 
     /**
      * @dataProvider getContentTypeIdsProvider
-     * @param [] $identifiers
-     * @param [] $expected
+     *
+     * @param string[] $identifiers
+     * @param array $expected Content Type identifier to ID map
+     *
+     * @throws \ErrorException
      */
-    public function testGetContentTypeIds($identifiers, $expected)
+    public function testGetContentTypeIds(array $identifiers, array $expected): void
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentclass.php');
         $gatewayService = $this->getGatewayService();
@@ -44,7 +50,10 @@ class ContentModelGatewayTest extends BaseTest
         $this->assertEquals($expected, $ids);
     }
 
-    public function testCountContentTypeFieldsByFieldType()
+    /**
+     * @throws \ErrorException
+     */
+    public function testCountContentTypeFieldsByFieldType(): void
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentclass_attribute.php');
         $gatewayService = $this->getGatewayService();
@@ -59,7 +68,10 @@ class ContentModelGatewayTest extends BaseTest
         $this->assertEquals(0, $count, 'Expected to find 0 content type fields');
     }
 
-    public function testGetContentTypeFieldTypeUpdateQuery()
+    /**
+     * @throws \ErrorException
+     */
+    public function testGetContentTypeFieldTypeUpdateQuery(): void
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentclass_attribute.php');
         $gatewayService = $this->getGatewayService();
@@ -74,36 +86,36 @@ class ContentModelGatewayTest extends BaseTest
         $this->assertEquals(0, $count2, 'Expected all field definitions to be converted');
     }
 
-    public function getRowCountOfContentObjectAttributesProvider()
+    public function getRowCountOfContentObjectAttributesProvider(): array
     {
         return [
             [
-                'ezxmltext',
+                ['ezxmltext'],
                 68,
                 2,
             ],
             [
-                'ezstring',
+                ['ezstring'],
                 68,
                 3,
             ],
             [
-                'foobar',
+                ['foobar'],
                 68,
                 0,
             ],
             [
-                'ezxmltext',
+                ['ezxmltext'],
                 69,
                 3,
             ],
             [
-                'ezxmltext',
+                ['ezxmltext'],
                 null,
                 5,
             ],
             [
-                'ezrichtext',
+                ['ezrichtext'],
                 null,
                 2,
             ],
@@ -117,12 +129,14 @@ class ContentModelGatewayTest extends BaseTest
 
     /**
      * @dataProvider getRowCountOfContentObjectAttributesProvider
-     * @param string $datatypeString
-     * @param int $contentId
-     * @param int $expectedCount
+     *
+     * @throws \ErrorException
      */
-    public function testGetRowCountOfContentObjectAttributes($datatypeString, $contentId, $expectedCount)
-    {
+    public function testGetRowCountOfContentObjectAttributes(
+        array $datatypeString,
+        ?int $contentId,
+        int $expectedCount
+    ): void {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentobject_attribute.php');
 
         $gatewayService = $this->getGatewayService();
@@ -131,11 +145,11 @@ class ContentModelGatewayTest extends BaseTest
         $this->assertEquals($expectedCount, $count, 'Number of attributes does not match');
     }
 
-    public function getFieldRowsProvider()
+    public function getFieldRowsProvider(): array
     {
         return [
             [ //test $contentId
-                'ezxmltext',
+                ['ezxmltext'],
                 68,
                 0,
                 100,
@@ -173,7 +187,7 @@ class ContentModelGatewayTest extends BaseTest
                 ],
             ],
             [ // test $offset, $limit
-                'ezxmltext',
+                ['ezxmltext'],
                 null,
                 0,
                 1,
@@ -196,7 +210,7 @@ class ContentModelGatewayTest extends BaseTest
                 ],
             ],
             [ // test $offset, $limit
-                'ezxmltext',
+                ['ezxmltext'],
                 null,
                 1,
                 1,
@@ -219,7 +233,7 @@ class ContentModelGatewayTest extends BaseTest
                 ],
             ],
             [ // test $offset, $limit
-                'ezxmltext',
+                ['ezxmltext'],
                 null,
                 1,
                 2,
@@ -374,55 +388,56 @@ class ContentModelGatewayTest extends BaseTest
 
     /**
      * @dataProvider getFieldRowsProvider
-     * @param string $datatypeString
-     * @param int $contentId
-     * @param int $offset
-     * @param int $limit
-     * @param [] $expectedRows
+     *
+     * @throws \ErrorException
      */
-    public function testGetFieldRows($datatypeString, $contentId, $offset, $limit, $expectedRows)
-    {
+    public function testGetFieldRows(
+        array $datatypeString,
+        ?int $contentId,
+        int $offset,
+        int $limit,
+        array $expectedRows
+    ): void {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentobject_attribute.php');
 
         $gatewayService = $this->getGatewayService();
         $statement = $gatewayService->getFieldRows($datatypeString, $contentId, $offset, $limit);
         $index = 0;
-        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-            $this->assertLessThan(\count($expectedRows), $index, 'Too many rows returned by getFieldRows');
+        while ($row = $statement->fetch(FetchMode::ASSOCIATIVE)) {
+            $this->assertLessThan(count($expectedRows), $index, 'Too many rows returned by getFieldRows');
             $this->assertEquals($expectedRows[$index], $row, 'Result from getFieldRows() did not return expected result');
             ++$index;
         }
-        $this->assertEquals(\count($expectedRows), $index, 'Too few rows returned by getFieldRows');
+        $this->assertEquals(count($expectedRows), $index, 'Too few rows returned by getFieldRows');
     }
 
-    protected function getFieldRows($contentId)
+    /**
+     * @throws \ErrorException
+     */
+    protected function getFieldRows(int $contentId): array
     {
         $gatewayService = $this->getGatewayService();
         $statement = $gatewayService->getFieldRows('ezxmltext', $contentId, 0, 100);
-        $rows = [];
-        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-            $rows[] = $row;
-        }
 
-        return $rows;
+        return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    public function getAllFieldRows()
+    /**
+     * @throws \ErrorException
+     */
+    public function getAllFieldRows(): array
     {
-        $query = $this->getDBAL()->createQueryBuilder();
+        $query = $this->getRawDatabaseConnection()->createQueryBuilder();
         $query->select('a.*')
             ->from('ezcontentobject_attribute', 'a')
             ->orderBy('a.id');
 
         $statement = $query->execute();
-        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-            $rows[] = $row;
-        }
 
-        return $rows;
+        return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
-    public function getUpdateFieldRowQueryProvider()
+    public function getUpdateFieldRowQueryProvider(): array
     {
         return [
             [
@@ -440,11 +455,10 @@ class ContentModelGatewayTest extends BaseTest
 
     /**
      * @dataProvider getUpdateFieldRowQueryProvider
-     * @param int $id
-     * @param int $version
-     * @param string $datatext
+     *
+     * @throws \ErrorException
      */
-    public function testGetUpdateFieldRowQuery($id, $version, $datatext)
+    public function testGetUpdateFieldRowQuery(int $id, int $version, string $datatext): void
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentobject_attribute.php');
 
@@ -455,7 +469,7 @@ class ContentModelGatewayTest extends BaseTest
         $updateQuery->execute();
 
         $updatedRows = $this->getAllFieldRows();
-        foreach ($originalRows as $key => $expectedRow) {
+        foreach ($originalRows as $expectedRow) {
             if ($expectedRow['id'] == $id && $expectedRow['version'] == $version) {
                 $expectedRow['data_text'] = $datatext;
                 $expectedRow['data_type_string'] = 'ezrichtext';
@@ -473,7 +487,7 @@ class ContentModelGatewayTest extends BaseTest
         }
     }
 
-    public function contentObjectAttributeExistsProvider()
+    public function contentObjectAttributeExistsProvider(): array
     {
         return [
             [
@@ -516,14 +530,16 @@ class ContentModelGatewayTest extends BaseTest
 
     /**
      * @dataProvider contentObjectAttributeExistsProvider
-     * @param int $objectId
-     * @param int $attributeId
-     * @param int $version
-     * @param string $language
-     * @param bool $expectedResult
+     *
+     * @throws \ErrorException
      */
-    public function testContentObjectAttributeExists($objectId, $attributeId, $version, $language, $expectedResult)
-    {
+    public function testContentObjectAttributeExists(
+        int $objectId,
+        int $attributeId,
+        int $version,
+        string $language,
+        bool $expectedResult
+    ): void {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentobject_attribute.php');
 
         $gatewayService = $this->getGatewayService();
@@ -532,7 +548,7 @@ class ContentModelGatewayTest extends BaseTest
         $this->assertEquals($expectedResult, $result, 'contentObjectAttributeExists() did not return expected value');
     }
 
-    public function updateContentObjectAttributeProvider()
+    public function updateContentObjectAttributeProvider(): array
     {
         return [
             [
@@ -568,14 +584,16 @@ class ContentModelGatewayTest extends BaseTest
 
     /**
      * @dataProvider updateContentObjectAttributeProvider
-     * @param string $xml
-     * @param int $objectId
-     * @param int $attributeId
-     * @param int $version
-     * @param string $language
+     *
+     * @throws \ErrorException
      */
-    public function testUpdateContentObjectAttribute($xml, $objectId, $attributeId, $version, $language)
-    {
+    public function testUpdateContentObjectAttribute(
+        string $xml,
+        int $objectId,
+        int $attributeId,
+        int $version,
+        string $language
+    ): void {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentobject_attribute.php');
 
         $gatewayService = $this->getGatewayService();
@@ -584,7 +602,7 @@ class ContentModelGatewayTest extends BaseTest
         $gatewayService->updateContentObjectAttribute($xml, $objectId, $attributeId, $version, $language);
 
         $updatedRows = $this->getAllFieldRows();
-        foreach ($originalRows as $key => $expectedRow) {
+        foreach ($originalRows as $expectedRow) {
             if ($expectedRow['contentobject_id'] == $objectId
                 && $expectedRow['id'] == $attributeId
                 && $expectedRow['version'] == $version
@@ -604,21 +622,18 @@ class ContentModelGatewayTest extends BaseTest
         }
     }
 
-    protected function getGatewayService()
+    /**
+     * @throws \ErrorException
+     */
+    protected function getGatewayService(): ContentModelGateway
     {
-        return $this->getSetupFactory()->getServiceContainer()->get('ezxmltext.persistence.legacy.content_model_gateway');
-    }
+        $serviceContainer = $this->getSetupFactory()->getServiceContainer();
 
-    public function getDB()
-    {
-        return $this->getSetupFactory()->getDB();
-    }
+        /** @var \eZ\Publish\Core\FieldType\XmlText\Persistence\Legacy\ContentModelGateway $contentModelGateway */
+        $contentModelGateway = $serviceContainer->get(
+            'ezxmltext.persistence.legacy.content_model_gateway'
+        );
 
-    public function getDBAL()
-    {
-        $handler = $this->getSetupFactory()->getDatabaseHandler();
-        $connection = $handler->getConnection();
-
-        return $connection;
+        return $contentModelGateway;
     }
 }

--- a/tests/lib/SetupFactory/LegacyEmptyDBSetupFactory.php
+++ b/tests/lib/SetupFactory/LegacyEmptyDBSetupFactory.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * This file is part of the eZ Platform XmlText Field Type package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace EzSystems\EzPlatformXmlTextFieldType\Tests\SetupFactory;
 
 use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy as CoreLegacySetupFactory;
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  */
 class LegacyEmptyDBSetupFactory extends CoreLegacySetupFactory
 {
-    protected function externalBuildContainer(ContainerBuilder $containerBuilder)
+    protected function externalBuildContainer(ContainerBuilder $containerBuilder): void
     {
         $loader = new YamlFileLoader(
             $containerBuilder,
@@ -38,24 +38,7 @@ class LegacyEmptyDBSetupFactory extends CoreLegacySetupFactory
         $containerBuilder->setParameter('kernel.cache_dir', __DIR__);
     }
 
-    public function getDatabaseHandler()
-    {
-        return parent::getDatabaseHandler();
-    }
-
-    public function getInitialData()
-    {
-        $data = parent::getInitialData();
-        $tables = [];
-        // just get the  table names in the dump, so that insertData() will truncate them
-        foreach (array_reverse(array_keys($data)) as $table) {
-            $tables[$table] = [];
-        }
-
-        return $tables;
-    }
-
-    public function resetDB()
+    public function resetDB(): void
     {
         $this->getRepository(true);
     }


### PR DESCRIPTION
This PR fixes outstanding issues discovered by CI and upgrades code and test setup to be compatible with eZ Platform v3.0.

**I recommend fast-forward merge** because the PR contains out of scope fix for [EZP-31512](https://jira.ez.no/browse/EZP-31512) (see ezsystems/ezplatform-richtext#128 for details).

I've upgraded test setup not to rely on dropped eZc Database Handler and while at it updated code to rely on Doctrine instead of PDO (`PDO::FETCH_*` usages). Using PDO constants in relevant changed places is deprecated in Doctrine.

There was also one outstanding change - Symfony `ContextErrorException` has been dropped in Symfony 4.0 in favor of native `\ErrorException`.

**TODO**:
- [x] Wait for Travis
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
