### PR TITLE
[WIP] EZP-31932: Added "fields-limit" option to ConvertXmlTextToRichTextCommand

### DIFF
--- a/lib/FieldType/XmlText/Persistence/Legacy/ContentModelGateway.php
+++ b/lib/FieldType/XmlText/Persistence/Legacy/ContentModelGateway.php
@@ -135,7 +135,7 @@ class ContentModelGateway
 
         $query = $this->dbal->createQueryBuilder();
         $query->select('*')
-            ->from(self::CONTENTCLASS_ATTRIBUTE_TABLE, 'a')
+            ->from(self::CONTENTOBJECT_ATTRIBUTE_TABLE, 'a')
             ->where(
                 $query->expr()->in(
                     'a.data_type_string',


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31932](https://jira.ez.no/browse/EZP-31932)
| **Type**           | Improvement
| **Target version** | `1.9`
| **BC breaks**      | no
| **Doc needed**     | yes

Some customers struggle with the `ConvertXmlTextToRichTextCommand` executing several days for large databases. The idea is to add `--fields-limit` option to run it against a fixed number of fields.

**TODO**:
- [x] Implement an improvement.
- [ ] Implement tests + specs and passing (`$ composer test`)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
