### PR TITLE
Added missing templates for line tag

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -145,6 +145,7 @@
   </xsl:template>
 
   <xsl:template match="line">
+    <xsl:apply-templates/>
   </xsl:template>
 
   <xsl:template match="paragraph">

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -142,10 +142,16 @@
 
   <xsl:template match="paragraph[@ez-temporary]">
     <xsl:apply-templates/>
+    <xsl:variable name="lines" select="line"/>
+    <xsl:for-each select="$lines">
+      <xsl:apply-templates/>
+      <xsl:if test='position() != last()'>
+        <xsl:text>&#xa;</xsl:text>
+      </xsl:if>
+    </xsl:for-each>
   </xsl:template>
 
   <xsl:template match="line">
-    <xsl:apply-templates/>
   </xsl:template>
 
   <xsl:template match="paragraph">

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/084-line-with-embed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/084-line-with-embed.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/">
+    <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+        <line>
+            <embed view="embed" size="medium" object_id="55" custom:offset="0" custom:limit="48" />
+        </line>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/084-line-with-embed.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/084-line-with-embed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
+    <ezembed view="embed" xlink:href="ezcontent://55">
+        <ezconfig>
+            <ezvalue key="size">medium</ezvalue>
+            <ezvalue key="offset">0</ezvalue>
+            <ezvalue key="limit">48</ezvalue>
+        </ezconfig>
+    </ezembed>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/EZEE-3495
| **Type**           | Bug
| **Target version** |  `1.8`
| **BC breaks**      | no
| **Doc needed**     | no

This PR adds missing handling for the `<line>` tag.

