### PR TITLE
Fixed missing 'is-linked' tag and wrong ezlink tag order

### DIFF
--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -275,9 +275,11 @@ class RichText implements Converter
     {
         $classAttributes = $node->attributes->getNamedItemNS('http://ez.no/xmlns/ezpublish/docbook/xhtml', 'class');
         if ($classAttributes == null) {
-            $isLinked = $node->lastChild->nodeName === 'ezlink';
             $class = 'ez-embed-type-image';
+            
+            $isLinked = $node->lastChild->nodeName === 'ezlink';
             $class .= $isLinked ? ' is-linked' : '';
+
             $node->setAttribute('ezxhtml:class', $class);
 
             return true;

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -274,8 +274,8 @@ class RichText implements Converter
     private function addXhtmlClassValue(DOMNode $node, $value)
     {
         $classAttributes = $node->attributes->getNamedItemNS('http://ez.no/xmlns/ezpublish/docbook/xhtml', 'class');
-        $isLinked = $node->lastChild->nodeName === 'ezlink';
         if ($classAttributes == null) {
+            $isLinked = $node->lastChild->nodeName === 'ezlink';
             $class = 'ez-embed-type-image';
             $class .= $isLinked ? ' is-linked' : '';
             $node->setAttribute('ezxhtml:class', $class);

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -274,8 +274,11 @@ class RichText implements Converter
     private function addXhtmlClassValue(DOMNode $node, $value)
     {
         $classAttributes = $node->attributes->getNamedItemNS('http://ez.no/xmlns/ezpublish/docbook/xhtml', 'class');
+        $isLinked = $node->lastChild->nodeName === 'ezlink';
         if ($classAttributes == null) {
-            $node->setAttribute('ezxhtml:class', 'ez-embed-type-image');
+            $class = 'ez-embed-type-image';
+            $class .= $isLinked ? ' is-linked' : '';
+            $node->setAttribute('ezxhtml:class', $class);
 
             return true;
         }

--- a/lib/FieldType/XmlText/Converter/RichText.php
+++ b/lib/FieldType/XmlText/Converter/RichText.php
@@ -276,7 +276,7 @@ class RichText implements Converter
         $classAttributes = $node->attributes->getNamedItemNS('http://ez.no/xmlns/ezpublish/docbook/xhtml', 'class');
         if ($classAttributes == null) {
             $class = 'ez-embed-type-image';
-            
+
             $isLinked = $node->lastChild->nodeName === 'ezlink';
             $class .= $isLinked ? ' is-linked' : '';
 

--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -608,11 +608,6 @@
           <xsl:with-param name="align" select="@align"/>
         </xsl:call-template>
       </xsl:if>
-      <xsl:if test="@*[starts-with( name( . ), 'ezlegacytmp-embed-link-' )]">
-        <xsl:element name="ezlink" namespace="http://docbook.org/ns/docbook">
-          <xsl:call-template name="addEmbedLinkAttributes"/>
-        </xsl:element>
-      </xsl:if>
       <xsl:if test="@size or @*[namespace-uri() = 'http://ez.no/namespaces/ezpublish3/custom/']">
         <xsl:element name="ezconfig" namespace="http://docbook.org/ns/docbook">
           <xsl:for-each select="@size | @*[namespace-uri() = 'http://ez.no/namespaces/ezpublish3/custom/']">
@@ -620,6 +615,11 @@
               <xsl:with-param name="attribute" select="current()"/>
             </xsl:call-template>
           </xsl:for-each>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="@*[starts-with( name( . ), 'ezlegacytmp-embed-link-' )]">
+        <xsl:element name="ezlink" namespace="http://docbook.org/ns/docbook">
+          <xsl:call-template name="addEmbedLinkAttributes"/>
         </xsl:element>
       </xsl:if>
     </xsl:element>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/027-linkedEmbed.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/027-linkedEmbed.xml
@@ -5,12 +5,12 @@
          xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
          version="5.0-variant ezpublish-1.0">
   <ezembed xlink:href="ezcontent://106" view="embed" xml:id="embed-id-1" ezxhtml:class="embed-class" ezxhtml:align="left">
-    <ezlink xlink:href="ezurl://95#fragment1" xlink:show="new" xml:id="link-id-1" xlink:title="Link title" ezxhtml:class="link-class"/>
     <ezconfig>
       <ezvalue key="size">medium</ezvalue>
       <ezvalue key="offset">10</ezvalue>
       <ezvalue key="limit">5</ezvalue>
     </ezconfig>
+    <ezlink xlink:href="ezurl://95#fragment1" xlink:show="new" xml:id="link-id-1" xlink:title="Link title" ezxhtml:class="link-class"/>
   </ezembed>
   <ezembed xlink:href="ezlocation://601" view="line" xml:id="embed-id-2" ezxhtml:class="embedClass2" ezxhtml:align="right">
     <ezlink xlink:href="ezlocation://202" xlink:show="none" ezxhtml:class="linkClass2"/>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/028-linkedEmbedInline.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/docbook/028-linkedEmbedInline.xml
@@ -8,9 +8,9 @@
     <ezlink xlink:href="ezcontent://106" xlink:show="new" xml:id="id4" xlink:title="Link title" ezxhtml:class="linkClass"/>
   </ezembedinline> for the otherwise unremarkable paragraph.</para>
   <para>This paragraph is just showing off its <ezembedinline xlink:href="ezcontent://501" view="embed-inline" xml:id="id5" ezxhtml:class="embedClass2" ezxhtml:align="right">
-    <ezlink xlink:href="ezcontent://105" xlink:show="none" xml:id="id6" xlink:title="Link title 2" ezxhtml:class="linkClass2"/>
     <ezconfig>
       <ezvalue key="size">medium</ezvalue>
     </ezconfig>
+    <ezlink xlink:href="ezcontent://105" xlink:show="none" xml:id="id6" xlink:title="Link title 2" ezxhtml:class="linkClass2"/>
   </ezembedinline> content.</para>
 </section>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/lossy/104-expandAndLinkEmbed.docbook.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/lossy/104-expandAndLinkEmbed.docbook.xml
@@ -8,12 +8,12 @@
     <link xlink:href="ezurl://72" xlink:show="none">Hello </link>
   </para>
   <ezembed view="embed" xlink:href="ezcontent://110">
-    <ezlink xlink:href="ezurl://72" xlink:show="none"/>
     <ezconfig>
       <ezvalue key="size">medium</ezvalue>
       <ezvalue key="offset">0</ezvalue>
       <ezvalue key="limit">5</ezvalue>
     </ezconfig>
+    <ezlink xlink:href="ezurl://72" xlink:show="none"/>
   </ezembed>
   <para ezxhtml:class="dire">
     <link xlink:href="ezurl://72" xlink:show="none"> goodbye</link>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/lossy/105-expandAndLinkEmbedWrapped.docbook.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/lossy/105-expandAndLinkEmbedWrapped.docbook.xml
@@ -8,12 +8,12 @@
   <para ezxhtml:class="grass">
     I<emphasis>have<link xlink:href="ezurl://73" xlink:show="none">no<emphasis role="strong">idea</emphasis></link></emphasis></para>
   <ezembed view="embed" xlink:href="ezcontent://106">
-    <ezlink xlink:href="ezurl://73" xlink:show="none"/>
     <ezconfig>
       <ezvalue key="size">medium</ezvalue>
       <ezvalue key="offset">0</ezvalue>
       <ezvalue key="limit">5</ezvalue>
     </ezconfig>
+    <ezlink xlink:href="ezurl://73" xlink:show="none"/>
   </ezembed>
   <para ezxhtml:class="grass"><emphasis><link xlink:href="ezurl://73" xlink:show="none"><emphasis role="strong">what is</emphasis>going</link>on</emphasis>here
   </para>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/lossy/106-expandAndLinkEmbedDoubleWrapped.docbook.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/lossy/106-expandAndLinkEmbedDoubleWrapped.docbook.xml
@@ -8,12 +8,12 @@
   <para>
     Why<emphasis>be<link xlink:href="ezurl://73" xlink:show="none">dumb<emphasis role="strong">if you've</emphasis></link></emphasis></para>
   <ezembed view="embed" xlink:href="ezcontent://106">
-    <ezlink xlink:href="ezurl://73" xlink:show="none"/>
     <ezconfig>
       <ezvalue key="size">medium</ezvalue>
       <ezvalue key="offset">0</ezvalue>
       <ezvalue key="limit">5</ezvalue>
     </ezconfig>
+    <ezlink xlink:href="ezurl://73" xlink:show="none"/>
   </ezembed>
   <para><emphasis><link xlink:href="ezurl://73" xlink:show="none"><emphasis role="strong">come</emphasis>to</link>find</emphasis>me?
   </para>

--- a/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/lossy/107-expandAndLinkEmbedDoubleWrapped2.docbook.xml
+++ b/tests/lib/FieldType/Converter/Xslt/_fixtures/ezxml/lossy/107-expandAndLinkEmbedDoubleWrapped2.docbook.xml
@@ -9,12 +9,12 @@
     <link xlink:href="ezurl://73" xlink:show="none">don't come in<emphasis role="strong">again like that,<emphasis role="strong">it isn't funny</emphasis></emphasis></link>
   </para>
   <ezembed view="embed" xlink:href="ezcontent://106">
-    <ezlink xlink:href="ezurl://73" xlink:show="none"/>
     <ezconfig>
       <ezvalue key="size">medium</ezvalue>
       <ezvalue key="offset">0</ezvalue>
       <ezvalue key="limit">5</ezvalue>
     </ezconfig>
+    <ezlink xlink:href="ezurl://73" xlink:show="none"/>
   </ezembed>
   <para>
     <link xlink:href="ezurl://73" xlink:show="none"><emphasis role="strong"><emphasis role="strong">and I can pay</emphasis>someone else</emphasis>to make the orchestrations</link>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/122-embed-linked-image-add-is-linked.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/122-embed-linked-image-add-is-linked.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<section
+        xmlns:image="http://ez.no/namespaces/ezpublish3/image/"
+        xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"
+        xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>
+        <link url_id="30">
+            <embed view="embed" size="medium" object_id="126" custom:offset="0" custom:limit="5"/>
+        </link>
+    </paragraph>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/122-embed-linked-image-add-is-linked.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/122-embed-linked-image-add-is-linked.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
+    <ezembed view="embed" ezxhtml:class="ez-embed-type-image is-linked" xlink:href="ezcontent://126">
+        <ezconfig>
+            <ezvalue key="size">medium</ezvalue>
+            <ezvalue key="offset">0</ezvalue>
+            <ezvalue key="limit">5</ezvalue>
+        </ezconfig>
+        <ezlink xlink:href="ezurl://30" xlink:show="none"/>
+    </ezembed>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/EZP-32345
| **Type**           | Bug
| **Target version** | `1.8`

This PR fixes the issue with the conversion command which caused links vanishing from the RichText editor by adding the missing `is-linked` class to the `<ezembed>` and placing `<ezlink>` tag after `<ezconfig>`.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement/fix tests
- [x] Ask for Code Review.
