### PR TITLE
Added conversion rule for valign=center

### DIFF
--- a/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
+++ b/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl
@@ -499,7 +499,14 @@
       </xsl:if>
       <xsl:if test="@custom:valign">
         <xsl:attribute name="valign">
-          <xsl:value-of select="@custom:valign"/>
+          <xsl:choose>
+            <xsl:when test="translate(@custom:valign, $uppercase, $lowercase) = 'center'">
+              <xsl:value-of select="'middle'"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="translate(@custom:valign, $uppercase, $lowercase)"/>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@xhtml:colspan">
@@ -545,7 +552,14 @@
       </xsl:if>
       <xsl:if test="@custom:valign">
         <xsl:attribute name="valign">
-          <xsl:value-of select="translate(@custom:valign, $uppercase, $lowercase)"/>
+          <xsl:choose>
+            <xsl:when test="translate(@custom:valign, $uppercase, $lowercase) = 'center'">
+              <xsl:value-of select="'middle'"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="translate(@custom:valign, $uppercase, $lowercase)"/>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:attribute>
       </xsl:if>
       <xsl:if test="@xhtml:colspan">

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/input/093-table-valign-center.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/input/093-table-valign-center.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/">
+    <section>
+        <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+            <table>
+                <tr>
+                    <td custom:valign="center">
+                        <paragraph>Lorem ipsum</paragraph>
+                    </td>
+                </tr>
+            </table>
+        </paragraph>
+    </section>
+</section>

--- a/tests/lib/FieldType/Converter/_fixtures/richtext/output/093-table-valign-center.xml
+++ b/tests/lib/FieldType/Converter/_fixtures/richtext/output/093-table-valign-center.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+  <informaltable>
+    <tbody>
+      <tr>
+        <td valign="middle">
+          <para>Lorem ipsum</para>
+        </td>
+      </tr>
+    </tbody>
+  </informaltable>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/EZP-32359

In the legacy XML Text field, there was a possibility that the table cell will have `valign` attribute set to `center` (probably pasting from MS Word) which is not a valid docbook and will fail RichText validation after conversion. 

This PR adds a conversion rule, so `center` is cast to `middle` for `valign` attribute.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests + specs and passing (`$ composer test`)
- [x] Ask for Code Review.
